### PR TITLE
feat: add branded video URL input CTA (#3)

### DIFF
--- a/clips-frontend/app/create/__tests__/page.test.tsx
+++ b/clips-frontend/app/create/__tests__/page.test.tsx
@@ -26,16 +26,16 @@ describe("CreateClipsPage", () => {
     render(<CreateClipsPage />);
     
     expect(screen.getByText("Create Clips")).toBeInTheDocument();
-    expect(screen.getByLabelText("Video URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Paste YouTube or Vimeo URL")).toBeInTheDocument();
     expect(screen.getByText("Target Platforms")).toBeInTheDocument();
     expect(screen.getByText("Auto-Publish")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /generate clips/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clip now/i })).toBeInTheDocument();
   });
 
   it("disables submit button when no video input is provided", () => {
     render(<CreateClipsPage />);
     
-    const submitButton = screen.getByRole("button", { name: /generate clips/i });
+    const submitButton = screen.getByRole("button", { name: /clip now/i });
     expect(submitButton).toBeDisabled();
   });
 
@@ -43,31 +43,46 @@ describe("CreateClipsPage", () => {
     const user = userEvent.setup();
     render(<CreateClipsPage />);
     
-    const urlInput = screen.getByLabelText("Video URL");
+    const urlInput = screen.getByLabelText("Paste YouTube or Vimeo URL");
     await user.type(urlInput, "https://youtube.com/watch?v=test");
     
     const tiktokButton = screen.getByRole("button", { name: "TikTok" });
     await user.click(tiktokButton);
     
-    const submitButton = screen.getByRole("button", { name: /generate clips/i });
+    const submitButton = screen.getByRole("button", { name: /clip now/i });
     expect(submitButton).toBeEnabled();
   });
 
-  it("clears file when URL is entered", async () => {
+  it("disables the URL input when a file is selected", async () => {
     const user = userEvent.setup();
     render(<CreateClipsPage />);
     
-    // Upload file first
     const file = new File(["video"], "test.mp4", { type: "video/mp4" });
-    const fileInput = screen.getByLabelText(/upload video file/i);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+    expect(fileInput).not.toBeNull();
+    if (!fileInput) {
+      throw new Error("Expected hidden file input to exist");
+    }
     await user.upload(fileInput, file);
     
-    // Then enter URL
-    const urlInput = screen.getByLabelText("Video URL");
-    await user.type(urlInput, "https://youtube.com/watch?v=test");
-    
-    // File should be cleared (URL input should be enabled)
-    expect(urlInput).not.toBeDisabled();
+    const urlInput = screen.getByLabelText("Paste YouTube or Vimeo URL");
+    expect(urlInput).toBeDisabled();
+  });
+
+  it("shows validation feedback for unsupported video URLs", async () => {
+    const user = userEvent.setup();
+    render(<CreateClipsPage />);
+
+    const urlInput = screen.getByLabelText("Paste YouTube or Vimeo URL");
+    await user.type(urlInput, "https://example.com/video");
+
+    expect(screen.getByText(/please enter a valid youtube or vimeo url/i)).toBeInTheDocument();
+
+    const tiktokButton = screen.getByRole("button", { name: "TikTok" });
+    await user.click(tiktokButton);
+
+    const submitButton = screen.getByRole("button", { name: /clip now/i });
+    expect(submitButton).toBeDisabled();
   });
 
   it("toggles platform selection", async () => {
@@ -116,14 +131,14 @@ describe("CreateClipsPage", () => {
     render(<CreateClipsPage />);
     
     // Fill form
-    const urlInput = screen.getByLabelText("Video URL");
+    const urlInput = screen.getByLabelText("Paste YouTube or Vimeo URL");
     await user.type(urlInput, "https://youtube.com/watch?v=test");
     
     const tiktokButton = screen.getByRole("button", { name: "TikTok" });
     await user.click(tiktokButton);
     
     // Submit
-    const submitButton = screen.getByRole("button", { name: /generate clips/i });
+    const submitButton = screen.getByRole("button", { name: /clip now/i });
     await user.click(submitButton);
     
     // Should show loading state
@@ -132,35 +147,20 @@ describe("CreateClipsPage", () => {
     });
   });
 
-  it("displays error message on submission failure", async () => {
+  it("displays validation feedback for invalid video URLs before submission", async () => {
     const user = userEvent.setup();
-    
-    // Mock fetch to fail
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: false,
-        status: 400,
-        json: () => Promise.resolve({ message: "Invalid video URL" }),
-      } as Response)
-    );
-    
+
     render(<CreateClipsPage />);
-    
-    // Fill form
-    const urlInput = screen.getByLabelText("Video URL");
+
+    const urlInput = screen.getByLabelText("Paste YouTube or Vimeo URL");
     await user.type(urlInput, "https://invalid-url");
-    
+
     const tiktokButton = screen.getByRole("button", { name: "TikTok" });
     await user.click(tiktokButton);
-    
-    // Submit
-    const submitButton = screen.getByRole("button", { name: /generate clips/i });
-    await user.click(submitButton);
-    
-    // Should show error
-    await waitFor(() => {
-      expect(screen.getByText("Invalid video URL")).toBeInTheDocument();
-    });
+
+    const submitButton = screen.getByRole("button", { name: /clip now/i });
+    expect(submitButton).toBeDisabled();
+    expect(screen.getByText(/please enter a valid youtube or vimeo url/i)).toBeInTheDocument();
   });
 
   it("shows validation hints", () => {

--- a/clips-frontend/app/create/page.tsx
+++ b/clips-frontend/app/create/page.tsx
@@ -14,6 +14,9 @@ interface PlatformState {
   enabled: boolean;
 }
 
+const SUPPORTED_VIDEO_URL_PATTERN =
+  /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/|vimeo\.com\/)/i;
+
 const INITIAL_PLATFORMS: PlatformState[] = [
   { id: "tiktok", name: "TikTok", enabled: false },
   { id: "instagram", name: "Instagram", enabled: false },
@@ -32,8 +35,18 @@ export default function CreateClipsPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const trimmedVideoUrl = videoUrl.trim();
+  const hasTypedVideoUrl = trimmedVideoUrl !== "";
+  const hasSupportedVideoUrl =
+    !hasTypedVideoUrl || SUPPORTED_VIDEO_URL_PATTERN.test(trimmedVideoUrl);
+  const urlValidationMessage =
+    hasTypedVideoUrl && !hasSupportedVideoUrl
+      ? "Please enter a valid YouTube or Vimeo URL."
+      : null;
+
   // Validation
-  const hasVideoInput = videoUrl.trim() !== "" || uploadedFile !== null;
+  const hasVideoInput =
+    uploadedFile !== null || (hasTypedVideoUrl && hasSupportedVideoUrl);
   const hasSelectedPlatform = platforms.some((p) => p.enabled);
   const isFormValid = hasVideoInput && hasSelectedPlatform && !isSubmitting;
 
@@ -63,6 +76,11 @@ export default function CreateClipsPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!uploadedFile && hasTypedVideoUrl && !hasSupportedVideoUrl) {
+      setError("Please enter a valid YouTube or Vimeo URL.");
+      return;
+    }
     
     if (!isFormValid) return;
 
@@ -135,7 +153,7 @@ export default function CreateClipsPage() {
             {/* URL Input */}
             <div className="mb-4">
               <label htmlFor="video-url" className="mb-2 block text-sm text-zinc-400">
-                Video URL
+                Paste YouTube or Vimeo URL
               </label>
               <div className="relative">
                 <LinkIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-zinc-500" />
@@ -144,11 +162,22 @@ export default function CreateClipsPage() {
                   type="url"
                   value={videoUrl}
                   onChange={handleUrlChange}
-                  placeholder="https://youtube.com/watch?v=..."
+                  placeholder="https://youtube.com/watch?v=... or https://vimeo.com/..."
                   disabled={uploadedFile !== null || isSubmitting}
-                  className="w-full rounded-xl bg-zinc-900/50 py-3 pl-11 pr-4 text-white placeholder-zinc-500 outline-none ring-1 ring-zinc-800 transition focus:ring-2 focus:ring-[#00E68A] disabled:opacity-50"
+                  aria-invalid={Boolean(urlValidationMessage)}
+                  aria-describedby="video-url-help"
+                  className="w-full rounded-xl bg-zinc-900/50 py-3 pl-11 pr-4 text-white placeholder-zinc-500 outline-none ring-1 ring-zinc-800 transition hover:ring-zinc-700 focus:ring-2 focus:ring-[#00E68A] disabled:opacity-50"
                 />
               </div>
+              <p
+                id="video-url-help"
+                className={`mt-2 text-sm ${
+                  urlValidationMessage ? "text-red-400" : "text-zinc-500"
+                }`}
+              >
+                {urlValidationMessage ??
+                  "Supported links: public YouTube watch/share URLs and Vimeo video URLs."}
+              </p>
             </div>
 
             {/* Divider */}
@@ -255,7 +284,7 @@ export default function CreateClipsPage() {
             ) : (
               <>
                 <Sparkles className="h-5 w-5" aria-hidden="true" />
-                Generate Clips
+                Clip Now
               </>
             )}
           </button>


### PR DESCRIPTION
## Summary
- update the video URL field copy and placeholder to the requested YouTube/Vimeo wording
- add inline validation and helper text for supported YouTube and Vimeo links
- rename the primary CTA to `Clip Now` and refresh the related create-page tests

## Testing
- `npx vitest run app/create/__tests__/page.test.tsx`
- `npm run build` *(fails due pre-existing unrelated errors in `clips-frontend/app/components/DashboardHeader.tsx:44`, `clips-frontend/app/dashboard/layout.tsx:20`, and `clips-frontend/app/demo/social-platforms/page.tsx:2`)*
