### PR TITLE
Add login-only Forgot password? link

### DIFF
--- a/clips-frontend/components/AuthForm.tsx
+++ b/clips-frontend/components/AuthForm.tsx
@@ -30,6 +30,7 @@ export default function AuthForm({ mode = "login" }: AuthFormProps) {
   const [fullName, setFullName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [resetMessage, setResetMessage] = useState(false);
 
   const handleAuthSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -123,6 +124,22 @@ export default function AuthForm({ mode = "login" }: AuthFormProps) {
             placeholder="••••••••"
             className="w-full bg-[#131A17] border border-[#1E2A24] text-white focus:border-brand/70 rounded-[12px] px-4 py-3.5 text-[14px] focus:outline-none focus:bg-[#161F1A] transition-colors placeholder-[#4A5D54]"
           />
+          {currentMode === "login" && (
+            <div className="flex justify-end mt-3">
+              <button
+                type="button"
+                onClick={() => setResetMessage(true)}
+                className="text-brand font-medium hover:underline text-[13px]"
+              >
+                Forgot password?
+              </button>
+            </div>
+          )}
+          {resetMessage && currentMode === "login" && (
+            <div className="text-[#8e9895] text-[13px] mt-3 text-right">
+              Password reset coming soon
+            </div>
+          )}
         </div>
 
         {error && <div className="text-red-400 text-[13px] text-center pt-1">{error}</div>}
@@ -139,9 +156,9 @@ export default function AuthForm({ mode = "login" }: AuthFormProps) {
       
       <div className="text-center mt-7 text-[13px] text-[#84908C]">
         {currentMode === "login" ? (
-          <>New here? <button type="button" onClick={() => setCurrentMode("signup")} className="text-brand font-medium hover:underline">Sign up free</button></>
+          <>New here? <button type="button" onClick={() => { setCurrentMode("signup"); setResetMessage(false); }} className="text-brand font-medium hover:underline">Sign up free</button></>
         ) : (
-          <>Already have an account? <button type="button" onClick={() => setCurrentMode("login")} className="text-brand font-medium hover:underline">Sign in</button></>
+          <>Already have an account? <button type="button" onClick={() => { setCurrentMode("login"); setResetMessage(false); }} className="text-brand font-medium hover:underline">Sign in</button></>
         )}
       </div>
     </div>


### PR DESCRIPTION
closes #161 

--Summary: Adds a [Forgot password?] action to the login form in [AuthForm]. The link appears only in login mode, is styled consistently with the existing Sign up free toggle, and shows a temporary message: Password reset coming soon.

--What changed:
Added a login-only [Forgot password?button below the password input
Shows a reset message on click
Keeps the link hidden during signup mode
Reuses existing brand link styling for visual consistency

--Acceptance criteria met:
Link appears under the password field in login mode
Click displays a placeholder reset message
Link is not shown in signup mode
Styling matches the existing toggle link

--Testing:
Verified [AuthForm.tsx] for no type/syntax errors after the change