### PR TITLE
[160] Google and Apple OAuth buttons are non-functional with no user feedback

### DIFF
--- a/clips-frontend/components/AuthForm.tsx
+++ b/clips-frontend/components/AuthForm.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from "lucide-react";
 import { useAuth } from "./AuthProvider";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useComingSoonToast } from "./useComingSoonToast";
 
 // Local inline SVG for Google/Apple to avoid external dependencies perfectly matching
 const GoogleIcon = () => (
@@ -23,6 +24,7 @@ interface AuthFormProps {
 export default function AuthForm({ mode = "login" }: AuthFormProps) {
   const { setUser } = useAuth();
   const router = useRouter();
+  const { showToast, ToastEl } = useComingSoonToast();
 
   const [currentMode, setCurrentMode] = useState<"login" | "signup">(mode);
   const [email, setEmail] = useState("");
@@ -71,15 +73,24 @@ export default function AuthForm({ mode = "login" }: AuthFormProps) {
       </p>
       
       <div className="space-y-[14px] mb-8">
-        <button className="w-full flex items-center justify-center gap-3 bg-surface-hover hover:bg-border border border-border text-white py-3.5 rounded-[12px] font-medium transition-all text-[14px]">
+        <button
+          type="button"
+          onClick={() => showToast("Google sign-in")}
+          className="w-full flex items-center justify-center gap-3 bg-surface-hover hover:bg-border border border-border text-white py-3.5 rounded-[12px] font-medium transition-all text-[14px]"
+        >
           <GoogleIcon />
           Continue with Google
         </button>
-        <button className="w-full flex items-center justify-center gap-3 bg-surface-hover hover:bg-border border border-border text-white py-3.5 rounded-[12px] font-medium transition-all text-[14px]">
+        <button
+          type="button"
+          onClick={() => showToast("Apple sign-in")}
+          className="w-full flex items-center justify-center gap-3 bg-surface-hover hover:bg-border border border-border text-white py-3.5 rounded-[12px] font-medium transition-all text-[14px]"
+        >
           <AppleIcon />
           Continue with Apple
         </button>
       </div>
+      {ToastEl}
 
       <div className="flex items-center gap-4 text-muted-foreground text-[11px] font-bold tracking-[0.1em] uppercase mb-8">
         <div className="flex-1 h-px bg-border" />


### PR DESCRIPTION
Adds onClick handlers to the Google and Apple OAuth buttons in AuthForm so that clicking them shows a dismissible toast notification instead of silently doing nothing.

## Changes

- Added type=button to both OAuth buttons to prevent accidental form submission
- Wired onClick on the Google button to show 'Google sign-in - Coming soon'
- Wired onClick on the Apple button to show 'Apple sign-in - Coming soon'
- Reuses the existing useComingSoonToast hook (auto-dismisses after 3s, manually dismissible)
- Behaviour is consistent for both buttons

## Acceptance Criteria Met

- Clicking either button shows an inline message such as 'Google sign-in coming soon'
- The message auto-disappears after 3 seconds and is also manually dismissible
- Buttons have type=button so they cannot accidentally submit the email/password form
- Behaviour is consistent for both Google and Apple buttons

Closes #160
