### PR TITLE
Wire up Phantom wallet, bell notifications, View All nav, and ClipCard actions

### DIFF
--- a/clips-frontend/app/dashboard/page.tsx
+++ b/clips-frontend/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import Link from "next/link";
 import  DashboardSidebar from "@/components/dashboard/DashboardSidebar";
 import DashboardHeader from "@/components/dashboard/DashboardHeader";
 import StatCard from "@/components/dashboard/StatCard";
@@ -84,7 +85,7 @@ export default function DashboardPage() {
           <div className="space-y-6">
             <div className="flex items-center justify-between">
               <h3 className="text-[20px] font-extrabold text-white tracking-tight">Recent Projects</h3>
-              <button className="text-[14px] font-bold text-brand hover:underline">View All</button>
+              <Link href="/projects" className="text-[14px] font-bold text-brand hover:underline">View All</Link>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 pb-2">

--- a/clips-frontend/app/platforms/page.tsx
+++ b/clips-frontend/app/platforms/page.tsx
@@ -74,6 +74,7 @@ const MetaMaskIcon = ({ className }: { className?: string }) => (
 export default function PlatformsPage() {
   const { user } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [phantomError, setPhantomError] = useState<string | null>(null);
   const {
     isConnected: walletConnected,
     isConnecting: walletConnecting,
@@ -223,6 +224,20 @@ export default function PlatformsPage() {
               </div>
             )}
 
+            {/* Phantom info banner */}
+            {phantomError && (
+              <div className="flex items-start gap-3 bg-brand/10 border border-brand/20 rounded-2xl px-5 py-4 mb-6">
+                <AlertCircle className="w-5 h-5 text-brand shrink-0 mt-0.5" />
+                <p className="text-[14px] text-brand/90 leading-snug flex-1">{phantomError}</p>
+                <button
+                  onClick={() => setPhantomError(null)}
+                  className="text-brand/70 hover:text-brand transition-colors shrink-0"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            )}
+
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <PlatformCard 
                 name="Phantom Wallet" 
@@ -231,6 +246,10 @@ export default function PlatformsPage() {
                 status="NOT LINKED" 
                 ctaText="Connect Phantom"
                 variant="horizontal"
+                onConnect={() => {
+                  setPhantomError("Phantom wallet support coming soon");
+                  setTimeout(() => setPhantomError(null), 4000);
+                }}
               />
               <PlatformCard 
                 name="MetaMask" 

--- a/clips-frontend/components/dashboard/DashboardHeader.tsx
+++ b/clips-frontend/components/dashboard/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Upload, Bell, Menu } from "lucide-react";
 import { useAuth } from "@/components/AuthProvider";
 import WalletConnectButton from "@/components/WalletConnectButton";
@@ -12,7 +12,25 @@ interface HeaderProps {
 export default function DashboardHeader({ onMenuClick }: HeaderProps) {
   const { user } = useAuth();
   const [isUploading, setIsUploading] = useState(false);
+  const [notifOpen, setNotifOpen] = useState(false);
+  const [notifRead, setNotifRead] = useState(false);
+  const notifRef = useRef<HTMLDivElement>(null);
   const firstName = user?.name?.split(' ')[0] || user?.profile?.username || "Guest";
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (notifRef.current && !notifRef.current.contains(e.target as Node)) {
+        setNotifOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleBellClick = () => {
+    setNotifOpen((prev) => !prev);
+    setNotifRead(true);
+  };
 
   const handleQuickUpload = async () => {
     if (isUploading) return;
@@ -118,10 +136,46 @@ export default function DashboardHeader({ onMenuClick }: HeaderProps) {
           <WalletConnectButton compact />
         </div>
 
-        <button className="w-11 h-11 rounded-xl bg-surface border border-border flex items-center justify-center text-muted hover:text-white transition-colors relative">
-          <Bell className="w-5 h-5" />
-          <div className="absolute top-3 right-3 w-2 h-2 bg-brand rounded-full border-2 border-surface" />
-        </button>
+        <div className="relative" ref={notifRef}>
+          <button className="w-11 h-11 rounded-xl bg-surface border border-border flex items-center justify-center text-muted hover:text-white transition-colors relative"
+            onClick={handleBellClick}
+            aria-label="Notifications"
+          >
+            <Bell className="w-5 h-5" />
+            {!notifRead && (
+              <div className="absolute top-3 right-3 w-2 h-2 bg-brand rounded-full border-2 border-surface" />
+            )}
+          </button>
+
+          {notifOpen && (
+            <div className="absolute right-0 mt-2 w-80 bg-[#0C120F] border border-white/10 rounded-2xl shadow-[0_8px_40px_rgba(0,0,0,0.5)] z-50 animate-in fade-in slide-in-from-top-2 duration-200 overflow-hidden">
+              <div className="px-5 py-4 border-b border-white/[0.06]">
+                <p className="text-[14px] font-bold text-white">Notifications</p>
+              </div>
+              <div className="divide-y divide-white/[0.04]">
+                <div className="px-5 py-4 flex items-start gap-3 hover:bg-white/[0.02] transition-colors">
+                  <div className="w-2 h-2 rounded-full bg-brand mt-1.5 shrink-0" />
+                  <div>
+                    <p className="text-[13px] font-semibold text-white leading-snug">3 new clips are ready</p>
+                    <p className="text-[11px] text-muted-foreground mt-0.5">Your AI finished processing your last stream.</p>
+                    <p className="text-[10px] text-subtle mt-1">2 minutes ago</p>
+                  </div>
+                </div>
+                <div className="px-5 py-4 flex items-start gap-3 hover:bg-white/[0.02] transition-colors">
+                  <div className="w-2 h-2 rounded-full bg-muted mt-1.5 shrink-0" />
+                  <div>
+                    <p className="text-[13px] font-semibold text-white leading-snug">TikTok earnings updated</p>
+                    <p className="text-[11px] text-muted-foreground mt-0.5">Your latest payout has been recorded.</p>
+                    <p className="text-[10px] text-subtle mt-1">1 hour ago</p>
+                  </div>
+                </div>
+              </div>
+              <div className="px-5 py-3 border-t border-white/[0.06]">
+                <p className="text-[11px] text-muted-foreground text-center">No more notifications</p>
+              </div>
+            </div>
+          )}
+        </div>
         
         <button 
           onClick={handleQuickUpload}

--- a/clips-frontend/components/projects/ClipCard.tsx
+++ b/clips-frontend/components/projects/ClipCard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import React, { useState, memo } from "react";
+import React, { useState, memo, useCallback } from "react";
 import { 
   Play, 
   Download, 
   Edit, 
   Check,
   Sparkles,
+  X,
+  Zap,
 } from "lucide-react";
 
 interface ClipCardProps {
@@ -20,6 +22,15 @@ interface ClipCardProps {
   onSelect: (id: string) => void;
 }
 
+function useToast() {
+  const [toast, setToast] = useState<{ message: string; type: "info" | "success" } | null>(null);
+  const show = useCallback((message: string, type: "info" | "success" = "info") => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  }, []);
+  return { toast, show };
+}
+
 const ClipCard = memo(function ClipCard({ 
   id, 
   title, 
@@ -31,6 +42,31 @@ const ClipCard = memo(function ClipCard({
   onSelect 
 }: ClipCardProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const { toast, show: showToast } = useToast();
+
+  const handleEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    showToast("Clip editor coming soon", "info");
+  };
+
+  const handleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // Trigger a mock download using the thumbnail URL as a stand-in
+    const a = document.createElement("a");
+    a.href = thumbnail;
+    a.download = `${title.replace(/\s+/g, "_")}.mp4`;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    showToast("Download started", "success");
+  };
+
+  const handlePreview = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    showToast("Preview coming soon", "info");
+  };
 
   const getScoreStyle = (s: number) => {
     if (s >= 90) return "bg-brand border-brand text-black shadow-[0_0_20px_rgba(0,229,143,0.4)]";
@@ -125,18 +161,49 @@ const ClipCard = memo(function ClipCard({
 
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <button className="p-1.5 text-muted-foreground hover:text-white transition-colors touch-manipulation" title="Edit">
+            <button
+              aria-label="Edit clip"
+              onClick={handleEdit}
+              className="p-1.5 text-muted-foreground hover:text-white transition-colors touch-manipulation"
+              title="Edit"
+            >
               <Edit className="w-4 h-4" />
             </button>
-            <button className="p-1.5 text-muted-foreground hover:text-white transition-colors touch-manipulation" title="Download">
+            <button
+              aria-label="Download clip"
+              onClick={handleDownload}
+              className="p-1.5 text-muted-foreground hover:text-white transition-colors touch-manipulation"
+              title="Download"
+            >
               <Download className="w-4 h-4" />
             </button>
           </div>
-          <button className="text-[11px] font-black text-brand uppercase tracking-widest flex items-center gap-1.5 hover:underline py-1.5 touch-manipulation">
+          <button
+            aria-label="Preview clip"
+            onClick={handlePreview}
+            className="text-[11px] font-black text-brand uppercase tracking-widest flex items-center gap-1.5 hover:underline py-1.5 touch-manipulation"
+          >
             PREVIEW <span className="text-[14px] leading-none mb-0.5">›</span>
           </button>
         </div>
       </div>
+
+      {/* In-card toast */}
+      {toast && (
+        <div className="absolute bottom-4 left-4 right-4 z-30 animate-in fade-in slide-in-from-bottom-2 duration-200">
+          <div className={`flex items-center gap-2.5 px-4 py-2.5 rounded-xl border shadow-lg backdrop-blur-md ${
+            toast.type === "success"
+              ? "bg-brand/10 border-brand/30 text-brand"
+              : "bg-[#0C120F]/90 border-white/10 text-white"
+          }`}>
+            {toast.type === "success"
+              ? <Check className="w-3.5 h-3.5 shrink-0" />
+              : <Zap className="w-3.5 h-3.5 shrink-0 text-brand" />
+            }
+            <p className="text-[12px] font-semibold">{toast.message}</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
closes #162 
closes #165 
closes #166 
closes #167

**PR Description**

This PR resolves four dead UI elements across the dashboard and platforms pages, making them interactive and user-facing.

---

**Task 1 — Phantom Wallet "Connect Phantom" button (`platforms/page.tsx`)**

The Phantom Wallet card had no `onConnect` prop wired up, so clicking the button did nothing. A local `phantomError` state was added to the page. The `onConnect` handler now sets a message — "Phantom wallet support coming soon" — which renders in a styled info banner (matching the existing MetaMask error banner pattern) and auto-dismisses after 4 seconds. The button already had loading state support via `isLoading` in `PlatformCard`, so no component changes were needed.

---

**Task 2 — Bell notification button (`components/dashboard/DashboardHeader.tsx`)**

The bell icon was a static button with a hardcoded red dot and no interactivity. The component now:
- Tracks `notifOpen` (panel visibility) and `notifRead` (badge state) in local state
- Uses a `notifRef` + `mousedown` outside-click listener (same pattern as `Navbar.tsx`) to close the panel when clicking away
- Renders a dropdown panel anchored to the bell button with two mock notifications and an empty-state footer
- Clears the red dot badge once the panel is opened for the first time

---

**Task 3 — "View All" projects button (`app/dashboard/page.tsx`)**

The "View All" button next to "Recent Projects" was a `<button>` with no handler or navigation. It has been replaced with a `<Link href="/projects">` from Next.js. The visual style (text-brand, font-bold, hover:underline) is unchanged.

---

**Task 4 — ClipCard action buttons (`components/projects/ClipCard.tsx`)**

The Edit, Download, and Preview buttons were purely decorative. Each now has a proper `onClick` handler and `aria-label`:

- **Edit** — shows an in-card toast: "Clip editor coming soon"
- **Download** — programmatically creates an `<a>` element pointing to the clip thumbnail as a stand-in asset, triggers a download, then shows "Download started"
- **Preview** — shows an in-card toast: "Preview coming soon"

A lightweight `useToast` hook (local to the file) drives a small animated toast that appears at the bottom of the card and auto-dismisses after 3 seconds. It supports `"info"` (green Zap icon) and `"success"` (green Check icon) variants.