### PR TITLE
fix: connect EarningsSummaryCards to useEarningsStore

### DIFF
--- a/clips-frontend/app/store/earningsStore.ts
+++ b/clips-frontend/app/store/earningsStore.ts
@@ -41,6 +41,9 @@ async function fetchEarningsFromAPI(): Promise<{
   totalEarnings: string;
   totalTrend: number;
   trendLabel: string;
+  totalFiat: { value: string; change: number };
+  cryptoRevenue: { value: string; change: number };
+  pendingPayouts: { value: string; change: number };
   breakdown: EarningsBreakdownItem[];
 }> {
   // TODO: replace with `fetch('/api/earnings')` when the endpoint is ready
@@ -49,6 +52,9 @@ async function fetchEarningsFromAPI(): Promise<{
     totalEarnings: "$12,450.80",
     totalTrend: 12.5,
     trendLabel: "+12.5% from last month",
+    totalFiat: { value: "$12,450.80", change: 12.5 },
+    cryptoRevenue: { value: "1.25 ETH", change: 8.2 },
+    pendingPayouts: { value: "$1,850.25", change: 0 },
     breakdown: MOCK_BREAKDOWN,
   };
 }
@@ -59,6 +65,9 @@ const initialState: EarningsState = {
   totalEarnings: "$0.00",
   totalTrend: 0,
   trendLabel: "",
+  totalFiat: { value: "$0.00", change: 0 },
+  cryptoRevenue: { value: "0.00 ETH", change: 0 },
+  pendingPayouts: { value: "$0.00", change: 0 },
   breakdown: [],
   lastFetchedAt: null,
   loading: false,
@@ -90,6 +99,9 @@ export const useEarningsStore = create<EarningsState & EarningsActions>(
           totalEarnings: data.totalEarnings,
           totalTrend: data.totalTrend,
           trendLabel: data.trendLabel,
+          totalFiat: data.totalFiat,
+          cryptoRevenue: data.cryptoRevenue,
+          pendingPayouts: data.pendingPayouts,
           breakdown: data.breakdown,
           lastFetchedAt: Date.now(),
           loading: false,
@@ -115,6 +127,9 @@ export const selectEarningsTotals = (s: EarningsState & EarningsActions) => ({
   totalEarnings: s.totalEarnings,
   totalTrend: s.totalTrend,
   trendLabel: s.trendLabel,
+  totalFiat: s.totalFiat,
+  cryptoRevenue: s.cryptoRevenue,
+  pendingPayouts: s.pendingPayouts,
 });
 
 /** Full breakdown list */

--- a/clips-frontend/app/store/types.ts
+++ b/clips-frontend/app/store/types.ts
@@ -102,6 +102,12 @@ export interface EarningsState {
   totalEarnings: string;
   totalTrend: number;
   trendLabel: string;
+  
+  /** Granular summary cards data */
+  totalFiat: { value: string; change: number };
+  cryptoRevenue: { value: string; change: number };
+  pendingPayouts: { value: string; change: number };
+
   breakdown: EarningsBreakdownItem[];
   /** ISO timestamp of the last successful fetch */
   lastFetchedAt: number | null;

--- a/clips-frontend/components/dashboard/EarningsSummaryCards.tsx
+++ b/clips-frontend/components/dashboard/EarningsSummaryCards.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { DollarSign, Clock } from "lucide-react";
 import EarningsSummaryCard from "./EarningsSummaryCard";
+import { useEarningsStore, selectEarningsTotals, selectEarningsMeta } from "@/app/store";
 
 // Ethereum icon as a simple inline SVG component (not in lucide-react)
 function EthIcon({ className }: { className?: string }) {
@@ -39,16 +40,31 @@ interface EarningsSummaryCardsProps {
   data?: EarningsSummaryData;
 }
 
-// Default mock data — replace with real API data when available
-const defaultData: EarningsSummaryData = {
-  totalFiat: { value: "$24,830.00", change: 14.2 },
-  cryptoRevenue: { value: "3.84 ETH", change: -5.7 },
-  pendingPayouts: { value: "$3,120.50", change: 0 },
-};
-
 export default function EarningsSummaryCards({
-  data = defaultData,
+  data: propData,
 }: EarningsSummaryCardsProps) {
+  const { fetchEarnings } = useEarningsStore();
+  const storeTotals = useEarningsStore(selectEarningsTotals);
+  const { loading } = useEarningsStore(selectEarningsMeta);
+
+  useEffect(() => {
+    fetchEarnings();
+  }, [fetchEarnings]);
+
+  const data = propData || storeTotals;
+
+  if (loading && !propData && data.totalFiat.value === "$0.00") {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {[1, 2, 3].map((i) => (
+          <div 
+            key={i} 
+            className="bg-surface/50 border border-border/50 rounded-[24px] h-[160px] animate-pulse" 
+          />
+        ))}
+      </div>
+    );
+  }
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       <EarningsSummaryCard


### PR DESCRIPTION
Removed hardcoded defaultData constants from EarningsSummaryCards.tsx.
Updated EarningsState in app/store/types.ts to include totalFiat, cryptoRevenue, and pendingPayouts.
Refactored earningsStore.ts to handle these granular fields and added them to the selectEarningsTotals selector.
Connected EarningsSummaryCards to the store using useEarningsStore and implemented a mount-time fetch.
Added a pulse-animation loading skeleton to replace the previous static fallback.
Closes #230 