### PR TITLE
fix: optimize ProjectCard thumbnails and implement fallback

### DIFF
--- a/clips-frontend/app/dashboard/page.tsx
+++ b/clips-frontend/app/dashboard/page.tsx
@@ -93,19 +93,19 @@ export default function DashboardPage() {
                 title="Apex Legends Clutch Moments" 
                 clipsCount={2} 
                 status="processing"
-                thumbnail="https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&q=80&w=400&h=400"
+                thumbnail="/projects/thumb1.png"
               />
               <ProjectCard 
                 title="React Native Tutorial 2024" 
                 clipsCount={12} 
                 status="completed"
-                thumbnail="https://images.unsplash.com/photo-1633356122544-f134324a6cee?auto=format&fit=crop&q=80&w=400&h=400"
+                thumbnail="/projects/thumb2.png"
               />
               <ProjectCard 
                 title="Weekly Podcast Highlight #42" 
                 clipsCount={5} 
                 status="completed"
-                thumbnail="https://images.unsplash.com/photo-1590602847861-f357a9332bbc?auto=format&fit=crop&q=80&w=400&h=400"
+                thumbnail="/projects/thumb3.png"
               />
             </div>
           </div>

--- a/clips-frontend/components/dashboard/ProjectCard.tsx
+++ b/clips-frontend/components/dashboard/ProjectCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import Image from "next/image";
 import { Play } from "lucide-react";
 
 interface ProjectCardProps {
@@ -11,10 +12,22 @@ interface ProjectCardProps {
 }
 
 export default function ProjectCard({ title, clipsCount, status, thumbnail }: ProjectCardProps) {
+  const [imgSrc, setImgSrc] = useState(thumbnail);
+
+  useEffect(() => {
+    setImgSrc(thumbnail);
+  }, [thumbnail]);
+
   return (
     <div className="bg-surface border border-border rounded-[24px] p-5 flex items-center gap-5 group hover:border-white/10 transition-all duration-300">
       <div className="w-24 h-24 rounded-[18px] overflow-hidden relative shrink-0">
-        <img src={thumbnail} alt={title} className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500" />
+        <Image 
+          src={imgSrc} 
+          alt={title} 
+          fill
+          className="object-cover group-hover:scale-110 transition-transform duration-500" 
+          onError={() => setImgSrc('/projects/thumb1.png')}
+        />
         <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
           <div className="w-8 h-8 rounded-full bg-brand/90 flex items-center justify-center text-black">
             <Play className="w-4 h-4 fill-current ml-0.5" />

--- a/clips-frontend/next.config.ts
+++ b/clips-frontend/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'api.dicebear.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Replaced hardcoded Unsplash thumbnail URLs with local repository assets in DashboardPage.tsx.
Refactored the ProjectCard component to use next/image instead of raw <img> tags.
Implemented a state-based onError fallback mechanism to ensure no broken images are displayed.
Added images.unsplash.com and api.dicebear.com to the remotePatterns list in next.config.ts.
Enhanced the visual stability of the dashboard by ensuring core assets are hosted locally.
Closes #232 