### PR TITLE
fix(#235): replace hardcoded ClipsStats values with coming-soon state

### DIFF
--- a/clips-frontend/components/clips/ClipsStats.tsx
+++ b/clips-frontend/components/clips/ClipsStats.tsx
@@ -2,33 +2,29 @@
 
 import React from "react";
 
-export default function ClipsStats() {
-  const stats = [
-    { label: "Clips Today", value: "4.8k", detail: "Viral potential detected" },
-    { label: "Viral Accuracy", value: "98%", detail: "AI engine confidence" },
-    { label: "Avg Sync Time", value: "2.1s", detail: "Fastest in the industry" },
-  ];
+const stats = [
+  { label: "Clips Today" },
+  { label: "Viral Accuracy" },
+  { label: "Avg Sync Time" },
+];
 
+export default function ClipsStats() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       {stats.map((stat) => (
-        <div 
+        <div
           key={stat.label}
           className="bg-background/40 backdrop-blur-md border border-white/[0.03] hover:border-brand/20 rounded-[24px] p-6 text-center transition-all duration-500 group relative overflow-hidden"
         >
-          {/* Subtle Glow Background */}
           <div className="absolute inset-0 bg-brand/[0.01] group-hover:bg-brand/[0.03] transition-all duration-500" />
-          
+
           <div className="relative z-10 space-y-1.5">
-            <p className="text-[28px] sm:text-[32px] font-black text-white group-hover:text-brand transition-colors tracking-tight">
-              {stat.value}
-            </p>
             <p className="text-[12px] font-bold text-muted-foreground uppercase tracking-wider group-hover:text-white transition-colors">
               {stat.label}
             </p>
-            <div className="pt-3 border-t border-white/[0.03] mt-3 opacity-0 group-hover:opacity-100 transition-opacity duration-500">
-               <p className="text-[10px] font-medium text-subtle uppercase tracking-widest">{stat.detail}</p>
-            </div>
+            <p className="text-[13px] font-semibold text-muted-foreground/60 uppercase tracking-widest">
+              Coming soon
+            </p>
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Summary

Closes #235

`ClipsStats` was rendering three stat cards with hardcoded values (`4.8k`, `98%`, `2.1s`) that were never fetched from any store or API. These marketing-style numbers could mislead users into thinking they represent live metrics.

## Changes

- Remove hardcoded `value` and `detail` fields from the stats array
- Each card now shows a **"Coming soon"** label instead of a fake number
- Card structure and hover animations are preserved
- When a real API endpoint is available, the values can be fetched and swapped in without changing the card layout

## Acceptance Criteria

- [x] Stats are not shown as fake live numbers
- [x] Cards show a clear "coming soon" state rather than misleading hardcoded values