### PR TITLE
Fix #214: Replace img with Next.js Image in NFTCard for optimization

### DIFF
--- a/clips-frontend/components/vault/NFTCard.tsx
+++ b/clips-frontend/components/vault/NFTCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, memo } from "react";
+import Image from 'next/image';
 import { 
   ExternalLink,
   Zap,
@@ -94,12 +95,11 @@ const NFTCard = memo(function NFTCard({
             onMouseLeave={() => setIsPlaying(false)}
           />
         ) : (
-          <img 
-            src={thumbnail} 
+          <Image
+            src={thumbnail}
             alt={title}
-            loading="lazy"
-            decoding="async"
-            className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
+            fill
+            className="object-cover transition-transform duration-700 group-hover:scale-110"
           />
         )}
 


### PR DESCRIPTION
This PR fixes issue #214 by replacing the plain `<img>` tag in `NFTCard.tsx` with Next.js `<Image>` component for better optimization, including lazy loading, WebP conversion, and responsive images.

## Changes Made:
- Added `import Image from 'next/image';` to the imports
- Replaced the `<img>` tag with `<Image>` using the `fill` prop to maintain aspect ratio
- Updated className to use `object-cover` for proper image scaling
- Maintained meaningful alt text using the `title` prop
- Video preview functionality remains unchanged

## Acceptance Criteria Met:
- ✅ NFTCard uses `next/image` for the thumbnail
- ✅ Alt text is meaningful (uses the `title` prop)
- ✅ Video preview path is unchanged

Closes #214