### PR TITLE
feat: add skeleton loading states to activity, platforms, and settings pages

### DIFF
--- a/clips-frontend/app/activity/page.tsx
+++ b/clips-frontend/app/activity/page.tsx
@@ -6,6 +6,7 @@ import DashboardHeader from "@/components/dashboard/DashboardHeader";
 import ActivityFeed from "@/components/wallet/ActivityFeed";
 import { useAutoStellarWallet } from "@/app/hooks/useAutoStellarWallet";
 import { Loader2, AlertCircle, Activity } from "lucide-react";
+import Skeleton from "@/components/ui/Skeleton";
 
 export default function ActivityPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -59,8 +60,39 @@ export default function ActivityPage() {
 
           {/* Loading state */}
           {status === "loading" && (
-            <div className="flex justify-center py-16">
-              <Loader2 className="w-6 h-6 text-brand animate-spin" />
+            <div className="bg-surface border border-border rounded-[24px] p-5 sm:p-6 space-y-6">
+              {/* Header Skeleton */}
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-6 w-6 rounded-lg" />
+              </div>
+              
+              {/* Filter Chips Skeleton */}
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4 rounded-full animate-pulse" />
+                <Skeleton className="h-7 w-12 rounded-lg" />
+                <Skeleton className="h-7 w-20 rounded-lg" />
+                <Skeleton className="h-7.5 w-16 rounded-lg" />
+              </div>
+
+              {/* Transactions Skeleton List */}
+              <div className="space-y-2">
+                {[...Array(5)].map((_, i) => (
+                  <div key={i} className="flex items-center gap-3 p-3 rounded-xl border border-border bg-surface-hover/50">
+                    <Skeleton className="w-8 h-8 rounded-lg shrink-0" />
+                    <div className="flex-1 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <Skeleton className="h-4 w-20" />
+                        <Skeleton className="h-4 w-24" />
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <Skeleton className="h-3 w-32" />
+                        <Skeleton className="h-3 w-16" />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
 

--- a/clips-frontend/app/platforms/page.tsx
+++ b/clips-frontend/app/platforms/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/components/AuthProvider";
 import { useWallet, truncateAddress } from "@/components/WalletProvider";
+import Skeleton from "@/components/ui/Skeleton";
 
 /* ================= TYPES ================= */
 
@@ -75,7 +76,7 @@ const MetaMaskIcon = ({ className }: { className?: string }) => (
 /* ================= PAGE ================= */
 
 export default function PlatformsPage() {
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -89,7 +90,10 @@ export default function PlatformsPage() {
     connectPhantom,
     disconnect: disconnectWallet,
     clearError: clearWalletError,
+    isRestoringSession,
   } = useWallet();
+
+  const pageLoading = authLoading || isRestoringSession;
 
   /* ================= DATA ================= */
 
@@ -210,32 +214,75 @@ export default function PlatformsPage() {
             Connect <span className="text-brand">Accounts</span>
           </h1>
 
-          {noResults && (
-            <p className="text-muted-foreground text-sm">
-              No platforms found.
-            </p>
-          )}
+          {pageLoading ? (
+            <>
+              <section className="space-y-4">
+                <SectionHeader title="Social Platforms" icon={Share2} />
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {[...Array(4)].map((_, i) => (
+                    <div key={i} className="bg-surface/40 border border-white/[0.03] rounded-[24px] p-8 flex flex-col gap-8">
+                      <div className="flex items-start justify-between">
+                        <Skeleton className="w-16 h-16 rounded-[22px]" />
+                        <Skeleton className="w-20 h-6 rounded-lg" />
+                      </div>
+                      <div className="space-y-2">
+                        <Skeleton className="h-6 w-1/3" />
+                        <Skeleton className="h-4 w-2/3" />
+                      </div>
+                      <Skeleton className="w-full h-12 rounded-xl" />
+                    </div>
+                  ))}
+                </div>
+              </section>
 
-          {filteredSocial.length > 0 && (
-            <section>
-              <SectionHeader title="Social Platforms" icon={Share2} />
-              <div className="grid grid-cols-2 gap-4">
-                {filteredSocial.map((p) => (
-                  <PlatformCard key={p.name} {...p} variant="vertical" />
-                ))}
-              </div>
-            </section>
-          )}
+              <section className="space-y-4">
+                <SectionHeader title="Web3 Wallets" icon={Wallet} />
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {[...Array(2)].map((_, i) => (
+                    <div key={i} className="bg-surface/40 border border-white/[0.03] rounded-[24px] p-6 flex items-center justify-between">
+                      <div className="flex items-center gap-5">
+                        <Skeleton className="w-14 h-14 rounded-full" />
+                        <div className="space-y-2">
+                          <Skeleton className="h-5 w-24" />
+                          <Skeleton className="h-4 w-40" />
+                        </div>
+                      </div>
+                      <Skeleton className="w-28 h-10 rounded-xl" />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            </>
+          ) : (
+            <>
+              {noResults && (
+                <p className="text-muted-foreground text-sm">
+                  No platforms found.
+                </p>
+              )}
 
-          {filteredWallets.length > 0 && (
-            <section>
-              <SectionHeader title="Web3 Wallets" icon={Wallet} />
-              <div className="grid grid-cols-2 gap-4">
-                {filteredWallets.map((p) => (
-                  <PlatformCard key={p.name} {...p} variant="horizontal" />
-                ))}
-              </div>
-            </section>
+              {filteredSocial.length > 0 && (
+                <section>
+                  <SectionHeader title="Social Platforms" icon={Share2} />
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {filteredSocial.map((p) => (
+                      <PlatformCard key={p.name} {...p} variant="vertical" />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {filteredWallets.length > 0 && (
+                <section>
+                  <SectionHeader title="Web3 Wallets" icon={Wallet} />
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {filteredWallets.map((p) => (
+                      <PlatformCard key={p.name} {...p} variant="horizontal" />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
           )}
 
           <HelpBanner />

--- a/clips-frontend/app/settings/page.tsx
+++ b/clips-frontend/app/settings/page.tsx
@@ -14,6 +14,9 @@ import {
   requestNotificationPermission,
   storePermission,
 } from "@/app/lib/notifications";
+import { useAuth } from "@/components/AuthProvider";
+import Skeleton from "@/components/ui/Skeleton";
+import TrustlineManager from "@/components/wallet/TrustlineManager";
 
 export default function SettingsPage() {
   const { showToast } = useToast();
@@ -31,6 +34,7 @@ export default function SettingsPage() {
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedMnemonic, setCopiedMnemonic] = useState(false);
 
+  const { isLoading: authLoading } = useAuth();
   const {
     isConnected,
     walletType,
@@ -38,7 +42,10 @@ export default function SettingsPage() {
     stellarSecret,
     stellarMnemonic,
     importStellarKey,
+    isRestoringSession,
   } = useWallet();
+
+  const pageLoading = authLoading || isRestoringSession;
 
   const isStellarConnected = isConnected && walletType === "stellar";
 
@@ -132,261 +139,320 @@ export default function SettingsPage() {
             <p className="text-muted-foreground text-sm mt-1">Configure your notifications, wallets, and recovery plans.</p>
           </div>
 
-          {/* Notifications */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-extrabold text-white">Push Notifications</h2>
-            
-            <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-              <div className="flex items-center gap-4">
-                {permission === "granted" ? (
-                  <div className="w-12 h-12 rounded-full bg-green-500/10 border border-green-500/25 flex items-center justify-center text-green-400 shrink-0">
-                    <Bell className="w-6 h-6" />
+          {pageLoading ? (
+            <div className="space-y-6">
+              {/* Push Notifications Skeleton */}
+              <div className="space-y-4">
+                <Skeleton className="h-6 w-40" />
+                <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                  <div className="flex items-center gap-4">
+                    <Skeleton className="w-12 h-12 rounded-full shrink-0" />
+                    <div className="space-y-2">
+                      <Skeleton className="h-5 w-44" />
+                      <Skeleton className="h-3 w-72" />
+                    </div>
                   </div>
-                ) : (
-                  <div className="w-12 h-12 rounded-full bg-red-500/10 border border-red-500/25 flex items-center justify-center text-red-400 shrink-0">
-                    <BellOff className="w-6 h-6" />
-                  </div>
-                )}
-                <div>
-                  <p className="font-bold text-white">
-                    {permission === "granted" ? "Notifications Enabled" : "Notifications Disabled"}
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    {permission === "granted"
-                      ? "You will receive updates when clip rendering is complete"
-                      : "Authorize browser notifications to receive background alerts"}
-                  </p>
+                  <Skeleton className="w-24 h-10 rounded-xl" />
                 </div>
               </div>
 
-              <div>
-                {permission === "granted" ? (
-                  <button
-                    onClick={handleDisableNotifications}
-                    className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-red-500/20 bg-red-500/5 hover:bg-red-500/15 text-red-400 text-xs font-bold transition-all cursor-pointer"
-                  >
-                    <X className="w-3.5 h-3.5" />
-                    Disable
-                  </button>
-                ) : (
-                  <button
-                    onClick={handleEnableNotifications}
-                    disabled={notificationsLoading || permission === "denied"}
-                    className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all disabled:opacity-50 cursor-pointer"
-                  >
-                    <Check className="w-3.5 h-3.5" />
-                    {notificationsLoading ? "Enabling..." : "Enable System Notifications"}
-                  </button>
-                )}
+              {/* Language Skeleton */}
+              <div className="space-y-4">
+                <Skeleton className="h-6 w-24" />
+                <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                  <div className="flex items-center gap-4">
+                    <Skeleton className="w-12 h-12 rounded-full shrink-0" />
+                    <div className="space-y-2">
+                      <Skeleton className="h-5 w-36" />
+                      <Skeleton className="h-3 w-80" />
+                    </div>
+                  </div>
+                  <Skeleton className="w-32 h-10 rounded-xl" />
+                </div>
+              </div>
+
+              <div className="h-px bg-white/5 my-4" />
+
+              {/* Advanced Wallet Settings Skeleton */}
+              <div className="space-y-4">
+                <Skeleton className="h-6 w-48" />
+                <div className="space-y-2">
+                  <Skeleton className="h-3 w-full" />
+                  <Skeleton className="h-3 w-2/3" />
+                </div>
+                <div className="bg-surface border border-white/5 rounded-2xl p-6">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                      <Skeleton className="w-12 h-12 rounded-full shrink-0" />
+                      <div className="space-y-2">
+                        <Skeleton className="h-5 w-44" />
+                        <Skeleton className="h-3 w-64" />
+                      </div>
+                    </div>
+                    <Skeleton className="w-11 h-6 rounded-full" />
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-
-          {/* Language / Locale Settings */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-extrabold text-white">Language</h2>
-
-            <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-              <div className="flex items-center gap-4">
-                <div className="w-12 h-12 rounded-full bg-brand/10 border border-brand/20 flex items-center justify-center text-brand shrink-0">
-                  <Globe className="w-6 h-6" />
-                </div>
-                <div>
-                  <p className="font-bold text-white">Interface Language</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    Choose your preferred language for the wallet interface
-                  </p>
-                </div>
-              </div>
-
-              <LocaleSwitcher />
-            </div>
-          </div>
-
-          <div className="h-px bg-white/5 my-4" />
-
-          {/* Advanced Wallet Settings */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-extrabold text-white">Advanced Wallet Mode</h2>
-            <p className="text-xs text-muted-foreground leading-relaxed">
-              Enable advanced wallet tools to manage on-chain Stellar keys, import custom keypairs, and set up Social Recovery guardians.
-            </p>
-
-            <div className="bg-surface border border-white/5 rounded-2xl p-6">
-              <div className="flex items-center justify-between mb-6">
-                <div className="flex items-center gap-4">
-                  <div className="w-12 h-12 rounded-full bg-brand/10 border border-brand/20 flex items-center justify-center text-brand shrink-0">
-                    <Shield className="w-6 h-6" />
-                  </div>
-                  <div>
-                    <p className="font-bold text-white">Developer & Wallet Mode</p>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      Toggle to reveal cryptographic secret keys and seed backups.
-                    </p>
-                  </div>
-                </div>
+          ) : (
+            <>
+              {/* Notifications */}
+              <div className="space-y-4">
+                <h2 className="text-lg font-extrabold text-white">Push Notifications</h2>
                 
-                <button
-                  onClick={() => setAdvancedWalletEnabled(!advancedWalletEnabled)}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer ${
-                    advancedWalletEnabled ? "bg-brand" : "bg-white/10"
-                  }`}
-                  aria-label="Toggle Advanced Wallet Mode"
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      advancedWalletEnabled ? "translate-x-6" : "translate-x-1"
-                    }`}
-                  />
-                </button>
+                <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                  <div className="flex items-center gap-4">
+                    {permission === "granted" ? (
+                      <div className="w-12 h-12 rounded-full bg-green-500/10 border border-green-500/25 flex items-center justify-center text-green-400 shrink-0">
+                        <Bell className="w-6 h-6" />
+                      </div>
+                    ) : (
+                      <div className="w-12 h-12 rounded-full bg-red-500/10 border border-red-500/25 flex items-center justify-center text-red-400 shrink-0">
+                        <BellOff className="w-6 h-6" />
+                      </div>
+                    )}
+                    <div>
+                      <p className="font-bold text-white">
+                        {permission === "granted" ? "Notifications Enabled" : "Notifications Disabled"}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {permission === "granted"
+                          ? "You will receive updates when clip rendering is complete"
+                          : "Authorize browser notifications to receive background alerts"}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div>
+                    {permission === "granted" ? (
+                      <button
+                        onClick={handleDisableNotifications}
+                        className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-red-500/20 bg-red-500/5 hover:bg-red-500/15 text-red-400 text-xs font-bold transition-all cursor-pointer"
+                      >
+                        <X className="w-3.5 h-3.5" />
+                        Disable
+                      </button>
+                    ) : (
+                      <button
+                        onClick={handleEnableNotifications}
+                        disabled={notificationsLoading || permission === "denied"}
+                        className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all disabled:opacity-50 cursor-pointer"
+                      >
+                        <Check className="w-3.5 h-3.5" />
+                        {notificationsLoading ? "Enabling..." : "Enable System Notifications"}
+                      </button>
+                    )}
+                  </div>
+                </div>
               </div>
 
-              {advancedWalletEnabled && (
-                <div className="space-y-6 animate-in fade-in slide-in-from-top-2 duration-300">
-                  
-                  {/* If Stellar Wallet is Connected */}
-                  {isStellarConnected ? (
-                    <div className="space-y-5">
-                      <div className="p-4 rounded-xl bg-black/40 border border-white/5">
-                        <div className="flex justify-between items-center mb-1">
-                          <span className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">Connected Stellar Address</span>
-                          <span className="text-[10px] px-2 py-0.5 rounded-full bg-brand/10 border border-brand/25 text-brand uppercase font-mono">Active</span>
-                        </div>
-                        <p className="text-xs font-mono text-white break-all mt-1">{address}</p>
-                      </div>
+              {/* Language / Locale Settings */}
+              <div className="space-y-4">
+                <h2 className="text-lg font-extrabold text-white">Language</h2>
 
-                      <div className="p-4 rounded-xl bg-black/40 border border-white/5 flex flex-col md:flex-row justify-between md:items-center gap-4">
-                        <div className="space-y-1">
-                          <p className="font-bold text-sm text-white">Reveal Secret Key</p>
-                          <p className="text-xs text-muted-foreground leading-normal max-w-md">
-                            Export the raw Stellar Secret Key (starts with S). Never share this key with anyone.
-                          </p>
-                          {showPrivateKey && (
-                            <p className="text-xs font-mono text-brand break-all bg-brand/5 border border-brand/20 p-2 rounded-lg mt-2 select-all">
-                              {stellarSecret}
-                            </p>
-                          )}
-                        </div>
-                        <div className="flex gap-2 shrink-0 items-end">
-                          <button
-                            onClick={() => setShowPrivateKey(!showPrivateKey)}
-                            className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-bold hover:text-brand hover:border-brand/30 transition-all flex items-center gap-1 cursor-pointer"
-                          >
-                            {showPrivateKey ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
-                            {showPrivateKey ? "Hide" : "Reveal"}
-                          </button>
-                          {showPrivateKey && (
-                            <button
-                              onClick={handleCopyKey}
-                              className="px-3 py-2 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all flex items-center gap-1 cursor-pointer"
-                            >
-                              {copiedKey ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
-                              Copy
-                            </button>
-                          )}
-                        </div>
-                      </div>
+                <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                  <div className="flex items-center gap-4">
+                    <div className="w-12 h-12 rounded-full bg-brand/10 border border-brand/20 flex items-center justify-center text-brand shrink-0">
+                      <Globe className="w-6 h-6" />
+                    </div>
+                    <div>
+                      <p className="font-bold text-white">Interface Language</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Choose your preferred language for the wallet interface
+                      </p>
+                    </div>
+                  </div>
 
-                      {stellarMnemonic && (
-                        <div className="p-4 rounded-xl bg-black/40 border border-white/5 flex flex-col md:flex-row justify-between md:items-center gap-4">
-                          <div className="space-y-1">
-                            <p className="font-bold text-sm text-white">Recovery Mnemonic Phrase</p>
-                            <p className="text-xs text-muted-foreground leading-normal max-w-md">
-                              This 12-word phrase restores your wallet connection. Store it offline.
-                            </p>
-                            {showMnemonic && (
-                              <p className="text-xs font-mono text-brand bg-brand/5 border border-brand/20 p-2.5 rounded-lg mt-2 leading-relaxed select-all">
-                                {stellarMnemonic}
+                  <LocaleSwitcher />
+                </div>
+              </div>
+
+              <div className="h-px bg-white/5 my-4" />
+
+              {/* Advanced Wallet Settings */}
+              <div className="space-y-4">
+                <h2 className="text-lg font-extrabold text-white">Advanced Wallet Mode</h2>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  Enable advanced wallet tools to manage on-chain Stellar keys, import custom keypairs, and set up Social Recovery guardians.
+                </p>
+
+                <div className="bg-surface border border-white/5 rounded-2xl p-6">
+                  <div className="flex items-center justify-between mb-6">
+                    <div className="flex items-center gap-4">
+                      <div className="w-12 h-12 rounded-full bg-brand/10 border border-brand/20 flex items-center justify-center text-brand shrink-0">
+                        <Shield className="w-6 h-6" />
+                      </div>
+                      <div>
+                        <p className="font-bold text-white">Developer & Wallet Mode</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                          Toggle to reveal cryptographic secret keys and seed backups.
+                        </p>
+                      </div>
+                    </div>
+                    
+                    <button
+                      onClick={() => setAdvancedWalletEnabled(!advancedWalletEnabled)}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer ${
+                        advancedWalletEnabled ? "bg-brand" : "bg-white/10"
+                      }`}
+                      aria-label="Toggle Advanced Wallet Mode"
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                          advancedWalletEnabled ? "translate-x-6" : "translate-x-1"
+                        }`}
+                      />
+                    </button>
+                  </div>
+
+                  {advancedWalletEnabled && (
+                    <div className="space-y-6 animate-in fade-in slide-in-from-top-2 duration-300">
+                      
+                      {/* If Stellar Wallet is Connected */}
+                      {isStellarConnected ? (
+                        <div className="space-y-5">
+                          <div className="p-4 rounded-xl bg-black/40 border border-white/5">
+                            <div className="flex justify-between items-center mb-1">
+                              <span className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">Connected Stellar Address</span>
+                              <span className="text-[10px] px-2 py-0.5 rounded-full bg-brand/10 border border-brand/25 text-brand uppercase font-mono">Active</span>
+                            </div>
+                            <p className="text-xs font-mono text-white break-all mt-1">{address}</p>
+                          </div>
+
+                          <div className="p-4 rounded-xl bg-black/40 border border-white/5 flex flex-col md:flex-row justify-between md:items-center gap-4">
+                            <div className="space-y-1">
+                              <p className="font-bold text-sm text-white">Reveal Secret Key</p>
+                              <p className="text-xs text-muted-foreground leading-normal max-w-md">
+                                Export the raw Stellar Secret Key (starts with S). Never share this key with anyone.
                               </p>
-                            )}
-                          </div>
-                          <div className="flex gap-2 shrink-0 items-end">
-                            <button
-                              onClick={() => setShowMnemonic(!showMnemonic)}
-                              className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-bold hover:text-brand hover:border-brand/30 transition-all flex items-center gap-1 cursor-pointer"
-                            >
-                              {showMnemonic ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
-                              {showMnemonic ? "Hide" : "Reveal"}
-                            </button>
-                            {showMnemonic && (
+                              {showPrivateKey && (
+                                <p className="text-xs font-mono text-brand break-all bg-brand/5 border border-brand/20 p-2 rounded-lg mt-2 select-all">
+                                  {stellarSecret}
+                                </p>
+                              )}
+                            </div>
+                            <div className="flex gap-2 shrink-0 items-end">
                               <button
-                                onClick={handleCopyMnemonic}
-                                className="px-3 py-2 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all flex items-center gap-1 cursor-pointer"
+                                onClick={() => setShowPrivateKey(!showPrivateKey)}
+                                className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-bold hover:text-brand hover:border-brand/30 transition-all flex items-center gap-1 cursor-pointer"
                               >
-                                {copiedMnemonic ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
-                                Copy
+                                {showPrivateKey ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+                                {showPrivateKey ? "Hide" : "Reveal"}
                               </button>
-                            )}
+                              {showPrivateKey && (
+                                <button
+                                  onClick={handleCopyKey}
+                                  className="px-3 py-2 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all flex items-center gap-1 cursor-pointer"
+                                >
+                                  {copiedKey ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+                                  Copy
+                                </button>
+                              )}
+                            </div>
                           </div>
+
+                          {stellarMnemonic && (
+                            <div className="p-4 rounded-xl bg-black/40 border border-white/5 flex flex-col md:flex-row justify-between md:items-center gap-4">
+                              <div className="space-y-1">
+                                <p className="font-bold text-sm text-white">Recovery Mnemonic Phrase</p>
+                                <p className="text-xs text-muted-foreground leading-normal max-w-md">
+                                  This 12-word phrase restores your wallet connection. Store it offline.
+                                </p>
+                                {showMnemonic && (
+                                  <p className="text-xs font-mono text-brand bg-brand/5 border border-brand/20 p-2.5 rounded-lg mt-2 leading-relaxed select-all">
+                                    {stellarMnemonic}
+                                  </p>
+                                )}
+                              </div>
+                              <div className="flex gap-2 shrink-0 items-end">
+                                <button
+                                  onClick={() => setShowMnemonic(!showMnemonic)}
+                                  className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-bold hover:text-brand hover:border-brand/30 transition-all flex items-center gap-1 cursor-pointer"
+                                >
+                                  {showMnemonic ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+                                  {showMnemonic ? "Hide" : "Reveal"}
+                                </button>
+                                {showMnemonic && (
+                                  <button
+                                    onClick={handleCopyMnemonic}
+                                    className="px-3 py-2 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all flex items-center gap-1 cursor-pointer"
+                                  >
+                                    {copiedMnemonic ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+                                    Copy
+                                  </button>
+                                )}
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Social Recovery Section inside advanced settings */}
+                          <SocialRecoveryConfig />
+
+                          {/* Trustline Manager */}
+                          <TrustlineManager
+                            publicKey={address!}
+                            secretKey={stellarSecret}
+                          />
+                        </div>
+                      ) : (
+                        // If Stellar wallet is NOT connected
+                        <div className="space-y-5">
+                          <div className="p-4 rounded-xl bg-white/[0.01] border border-white/5 border-dashed text-center">
+                            <Wallet className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
+                            <p className="text-xs font-semibold text-muted-foreground">
+                              Stellar Wallet is currently disconnected. Please connect or generate a wallet to enable advanced modes.
+                            </p>
+                          </div>
+
+                          <div className="max-w-md mx-auto">
+                            <WalletConnectButton />
+                          </div>
+
+                          <div className="h-px bg-white/5 my-4" />
+
+                          {/* Import Key Form */}
+                          <form onSubmit={handleImportKeySubmit} className="space-y-3.5">
+                            <div className="space-y-2">
+                              <label className="block text-[11px] font-bold text-muted-foreground tracking-wider uppercase">
+                                Or Import Stellar Private Key
+                              </label>
+                              <input
+                                type="password"
+                                placeholder="Starts with 'S'... (56 characters)"
+                                value={importKeyInput}
+                                onChange={(e) => setImportKeyInput(e.target.value)}
+                                className="w-full bg-input border border-white/5 text-white focus:border-brand/40 rounded-xl px-4 py-3 text-xs focus:outline-none transition-colors"
+                              />
+                            </div>
+
+                            {importError && (
+                              <div className="p-3 bg-red-950/40 border border-red-500/20 rounded-xl text-center">
+                                <span className="text-xs text-red-400 font-semibold">{importError}</span>
+                              </div>
+                            )}
+
+                            {importSuccess && (
+                              <div className="p-3 bg-emerald-950/40 border border-emerald-500/20 rounded-xl text-center">
+                                <span className="text-xs text-emerald-400 font-semibold">Stellar private key imported successfully!</span>
+                              </div>
+                            )}
+
+                            <button
+                              type="submit"
+                              className="w-full py-3.5 rounded-xl border border-white/10 hover:border-brand/35 text-white hover:text-brand transition-colors text-xs font-bold cursor-pointer"
+                            >
+                              Import Secret Key
+                            </button>
+                          </form>
                         </div>
                       )}
 
-                      {/* Social Recovery Section inside advanced settings */}
-                      <SocialRecoveryConfig />
-
-                      {/* Trustline Manager */}
-                      <TrustlineManager
-                        publicKey={address!}
-                        secretKey={stellarSecret}
-                      />
-                    </div>
-                  ) : (
-                    // If Stellar wallet is NOT connected
-                    <div className="space-y-5">
-                      <div className="p-4 rounded-xl bg-white/[0.01] border border-white/5 border-dashed text-center">
-                        <Wallet className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
-                        <p className="text-xs font-semibold text-muted-foreground">
-                          Stellar Wallet is currently disconnected. Please connect or generate a wallet to enable advanced modes.
-                        </p>
-                      </div>
-
-                      <div className="max-w-md mx-auto">
-                        <WalletConnectButton />
-                      </div>
-
-                      <div className="h-px bg-white/5 my-4" />
-
-                      {/* Import Key Form */}
-                      <form onSubmit={handleImportKeySubmit} className="space-y-3.5">
-                        <div className="space-y-2">
-                          <label className="block text-[11px] font-bold text-muted-foreground tracking-wider uppercase">
-                            Or Import Stellar Private Key
-                          </label>
-                          <input
-                            type="password"
-                            placeholder="Starts with 'S'... (56 characters)"
-                            value={importKeyInput}
-                            onChange={(e) => setImportKeyInput(e.target.value)}
-                            className="w-full bg-input border border-white/5 text-white focus:border-brand/40 rounded-xl px-4 py-3 text-xs focus:outline-none transition-colors"
-                          />
-                        </div>
-
-                        {importError && (
-                          <div className="p-3 bg-red-950/40 border border-red-500/20 rounded-xl text-center">
-                            <span className="text-xs text-red-400 font-semibold">{importError}</span>
-                          </div>
-                        )}
-
-                        {importSuccess && (
-                          <div className="p-3 bg-emerald-950/40 border border-emerald-500/20 rounded-xl text-center">
-                            <span className="text-xs text-emerald-400 font-semibold">Stellar private key imported successfully!</span>
-                          </div>
-                        )}
-
-                        <button
-                          type="submit"
-                          className="w-full py-3.5 rounded-xl border border-white/10 hover:border-brand/35 text-white hover:text-brand transition-colors text-xs font-bold cursor-pointer"
-                        >
-                          Import Secret Key
-                        </button>
-                      </form>
                     </div>
                   )}
-
                 </div>
-              )}
-            </div>
-          </div>
+              </div>
+            </>
+          )}
         </div>
       </main>
     </div>

--- a/clips-frontend/components/wallet/ActivityFeed.tsx
+++ b/clips-frontend/components/wallet/ActivityFeed.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { getStellarLabUrl } from "@/app/lib/networkConfig";
 import { useToast } from "@/hooks/useToast";
+import Skeleton from "@/components/ui/Skeleton";
 
 export interface ActivityTransaction {
   id: string;
@@ -259,12 +260,22 @@ export default function ActivityFeed({
 
       {/* Loading state */}
       {loading && allTxs.length === 0 && (
-        <div
-          className="flex justify-center py-8"
-          role="status"
-          aria-live="polite"
-        >
-          <Loader2 className="w-5 h-5 text-brand animate-spin" aria-hidden="true" />
+        <div className="space-y-2" role="status" aria-label="Loading transactions">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="flex items-center gap-3 p-3 rounded-xl border border-border bg-surface-hover/50">
+              <Skeleton className="w-8 h-8 rounded-lg shrink-0" />
+              <div className="flex-1 space-y-2">
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-3 w-32" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+              </div>
+            </div>
+          ))}
           <span className="sr-only">Loading transactions</span>
         </div>
       )}


### PR DESCRIPTION
### description 
Several forms use placeholder text as the only label, which is not accessible. Placeholders disappear when the user starts typing and are not reliably announced by screen readers.

useUndoRedo creates a new div[aria-live="polite"] element, appends it to the DOM, sets its text, then removes it after 1 second on every undo/redo action. Screen readers may not announce content from elements that are immediately removed. A persistent live region is the correct pattern.

- closes #455 
- Closes #456 
- closes #457 
- closes #458 
