### PR TITLE
Replace polling with SSE for job status (#444)

### DIFF
--- a/clips-frontend/app/api/jobs/[id]/route.ts
+++ b/clips-frontend/app/api/jobs/[id]/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { jobStore } from "../shared/jobStore";
 
 /**
  * Mock API endpoint for job status
  * In production, this would fetch from a real backend/database
  */
-
-// In-memory storage for demo purposes
-// Production would use Redis/Database
-const jobStore = new Map<string, any>();
 
 export async function GET(
   request: NextRequest,

--- a/clips-frontend/app/api/jobs/[id]/stream/route.ts
+++ b/clips-frontend/app/api/jobs/[id]/stream/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest } from "next/server";
+import { jobStore } from "../../shared/jobStore";
+
+// In-memory storage for demo purposes (shared with main job route)
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id: jobId } = await context.params;
+
+  // Check if job exists in store
+  let job = jobStore.get(jobId);
+
+  // For demo: simulate job progress if not exists
+  if (!job) {
+    job = {
+      id: jobId,
+      progress: 0,
+      status: "processing",
+      momentsFound: 0,
+      estimatedSecondsRemaining: 300,
+      createdAt: Date.now(),
+    };
+    jobStore.set(jobId, job);
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      // Send initial status immediately
+      sendUpdate(controller, job);
+
+      // Simulate progress updates every 500ms (per acceptance criteria)
+      const intervalId = setInterval(() => {
+        // Refresh job from store (in case other requests updated it)
+        job = jobStore.get(jobId);
+
+        if (job.status === "processing") {
+          const elapsed = (Date.now() - job.createdAt) / 1000;
+
+          // Simulate progress: ~30% per minute (0.5% per second)
+          const newProgress = Math.min(95, Math.floor(elapsed * 0.5));
+
+          if (newProgress !== job.progress) {
+            job.progress = newProgress;
+            job.estimatedSecondsRemaining = Math.max(0, 300 - elapsed);
+
+            // Randomly find moments
+            if (newProgress > 20 && job.momentsFound === 0) {
+              job.momentsFound = Math.floor(Math.random() * 5) + 1;
+            }
+            if (newProgress > 60 && job.momentsFound < 3) {
+              job.momentsFound = Math.floor(Math.random() * 8) + 3;
+            }
+
+            jobStore.set(jobId, job);
+          }
+
+          // Complete at 95% after 180 seconds
+          if (newProgress >= 95 && elapsed > 180) {
+            job.status = "complete";
+            job.progress = 100;
+            job.estimatedSecondsRemaining = 0;
+            jobStore.set(jobId, job);
+            sendUpdate(controller, job);
+            clearInterval(intervalId);
+            controller.close();
+            return;
+          }
+
+          sendUpdate(controller, job);
+        } else {
+          sendUpdate(controller, job);
+          clearInterval(intervalId);
+          controller.close();
+        }
+      }, 500);
+
+      // Handle client disconnect
+      request.signal.addEventListener("abort", () => {
+        clearInterval(intervalId);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    },
+  });
+}
+
+function sendUpdate(controller: ReadableStreamDefaultController, data: any) {
+  const payload = JSON.stringify({
+    progress: data.progress,
+    status: data.status,
+    momentsFound: data.momentsFound,
+    estimatedSecondsRemaining: data.estimatedSecondsRemaining,
+  });
+  controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+}

--- a/clips-frontend/app/api/jobs/shared/jobStore.ts
+++ b/clips-frontend/app/api/jobs/shared/jobStore.ts
@@ -1,0 +1,3 @@
+// Shared in-memory job storage for demo purposes
+// Production would use Redis/Database
+export const jobStore = new Map<string, any>();

--- a/clips-frontend/app/hooks/useProcessingStatus.ts
+++ b/clips-frontend/app/hooks/useProcessingStatus.ts
@@ -12,12 +12,13 @@ interface JobStatus {
 }
 
 /**
- * Hook to poll job status from the backend
+ * Hook to get job status from the backend (uses SSE first, falls back to polling)
  * @param jobId - The job ID to poll
  * @param enabled - Whether polling is enabled (default: true)
  */
 export function useProcessingStatus(jobId: string | null, enabled: boolean = true) {
   const { update, startProcess, resetProcess } = useProcessStore();
+  const eventSourceRef = useRef<EventSource | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const isPollingRef = useRef(false);
 
@@ -28,6 +29,35 @@ export function useProcessingStatus(jobId: string | null, enabled: boolean = tru
     }
     isPollingRef.current = false;
   }, []);
+
+  const stopSSE = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  const stopAll = useCallback(() => {
+    stopSSE();
+    stopPolling();
+  }, [stopSSE, stopPolling]);
+
+  const updateFromData = useCallback((data: JobStatus) => {
+    update({
+      progress: data.progress,
+      status: data.status,
+      momentsFound: data.momentsFound,
+      estimatedSecondsRemaining: data.estimatedSecondsRemaining,
+    });
+
+    if (data.status === "complete" || data.status === "error") {
+      stopAll();
+
+      if (data.status === "complete") {
+        update({ completedAt: Date.now() });
+      }
+    }
+  }, [update, stopAll]);
 
   const fetchStatus = useCallback(async () => {
     if (!jobId || isPollingRef.current) return;
@@ -40,49 +70,53 @@ export function useProcessingStatus(jobId: string | null, enabled: boolean = tru
       }
 
       const data: JobStatus = await response.json();
-
-      // Update the process store with live data
-      update({
-        progress: data.progress,
-        status: data.status,
-        momentsFound: data.momentsFound,
-        estimatedSecondsRemaining: data.estimatedSecondsRemaining,
-      });
-
-      // Stop polling if job is complete or errored
-      if (data.status === "complete" || data.status === "error") {
-        stopPolling();
-        
-        if (data.status === "complete") {
-          update({ completedAt: Date.now() });
-        }
-      }
+      updateFromData(data);
     } catch (error) {
       console.error("Error fetching job status:", error);
-      // Don't stop polling on network errors - will retry
     }
-  }, [jobId, update, stopPolling]);
+  }, [jobId, updateFromData]);
 
   useEffect(() => {
     if (!enabled || !jobId) {
-      stopPolling();
+      stopAll();
       return;
     }
 
-    // Start polling immediately
-    isPollingRef.current = true;
-    fetchStatus();
+    // Try SSE first
+    const startSSE = () => {
+      const es = new EventSource(`/api/jobs/${jobId}/stream`);
+      eventSourceRef.current = es;
 
-    // Then poll every 3 seconds
-    intervalRef.current = setInterval(fetchStatus, 3000);
+      es.onmessage = (event) => {
+        try {
+          const data: JobStatus = JSON.parse(event.data);
+          updateFromData(data);
+        } catch (error) {
+          console.error("Error parsing SSE data:", error);
+        }
+      };
 
-    // Cleanup on unmount
-    return () => {
-      stopPolling();
+      es.onerror = () => {
+        console.warn("SSE connection failed, falling back to polling");
+        stopSSE();
+        startPollingFallback();
+      };
     };
-  }, [jobId, enabled, fetchStatus, stopPolling]);
 
-  return { stopPolling };
+    const startPollingFallback = () => {
+      isPollingRef.current = true;
+      fetchStatus();
+      intervalRef.current = setInterval(fetchStatus, 3000);
+    };
+
+    startSSE();
+
+    return () => {
+      stopAll();
+    };
+  }, [jobId, enabled, fetchStatus, updateFromData, stopAll]);
+
+  return { stopPolling: stopAll };
 }
 
 /**


### PR DESCRIPTION
- Add /api/jobs/[id]/stream SSE endpoint
- Update useProcessingStatus to use SSE first, fall back to polling
- Share jobStore between API routes
- Keep useProcessingStatus API unchanged
- SSE updates every 500ms
closes #444