### PR TITLE
Fix auth onboarding, session sync, redirects, and wallet restore.

### DIFF
--- a/clips-frontend/__tests__/components/AuthProvider.test.tsx
+++ b/clips-frontend/__tests__/components/AuthProvider.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { render, waitFor, act } from "@testing-library/react";
+import { AuthProvider, useAuth } from "@/components/AuthProvider";
+import { useSession } from "next-auth/react";
+import { useRouter, usePathname } from "next/navigation";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+}));
+
+jest.mock("@/app/store", () => ({
+  useUserStore: (selector: (state: { setProfile: jest.Mock; clearUser: jest.Mock }) => unknown) =>
+    selector({
+      setProfile: jest.fn(),
+      clearUser: jest.fn(),
+    }),
+  useDashboardStore: {
+    getState: () => ({ fetchDashboard: jest.fn() }),
+  },
+  useEarningsStore: {
+    getState: () => ({ fetchEarnings: jest.fn() }),
+  },
+}));
+
+function AuthProbe() {
+  const { user, setUser, isLoading } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="email">{user?.email ?? ""}</span>
+      <button
+        type="button"
+        onClick={() =>
+          setUser({
+            id: "mock-1",
+            email: "mock@example.com",
+            onboardingStep: 3,
+          })
+        }
+      >
+        mock-login
+      </button>
+    </div>
+  );
+}
+
+describe("AuthProvider", () => {
+  const push = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    (usePathname as jest.Mock).mockReturnValue("/dashboard");
+  });
+
+  it("populates localStorage from a NextAuth session on login", async () => {
+    (useSession as jest.Mock).mockReturnValue({
+      data: {
+        user: {
+          email: "oauth@example.com",
+          name: "OAuth User",
+          onboardingStep: 3,
+        },
+      },
+      status: "authenticated",
+    });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem("clipcash_user")).toContain("oauth@example.com");
+    });
+  });
+
+  it("clears localStorage when the NextAuth session expires", async () => {
+    let sessionStatus: "authenticated" | "unauthenticated" = "authenticated";
+    let sessionData: { user: { email: string; name: string; onboardingStep: number } } | null =
+      {
+        user: {
+          email: "oauth@example.com",
+          name: "OAuth User",
+          onboardingStep: 3,
+        },
+      };
+
+    (useSession as jest.Mock).mockImplementation(() => ({
+      data: sessionData,
+      status: sessionStatus,
+    }));
+
+    const { rerender } = render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem("clipcash_user")).toContain("oauth@example.com");
+    });
+
+    sessionStatus = "unauthenticated";
+    sessionData = null;
+
+    rerender(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem("clipcash_user")).toBeNull();
+    });
+  });
+
+  it("keeps mock login across session unauthenticated state", async () => {
+    (useSession as jest.Mock).mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    });
+
+    const { getByText, getByTestId } = render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    await act(async () => {
+      getByText("mock-login").click();
+    });
+
+    expect(localStorage.getItem("clipcash_user")).toContain("mock@example.com");
+    expect(getByTestId("email")).toHaveTextContent("mock@example.com");
+  });
+
+  it("redirects unauthenticated users away from protected routes", async () => {
+    (useSession as jest.Mock).mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    });
+    (usePathname as jest.Mock).mockReturnValue("/dashboard");
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/login");
+    });
+  });
+});

--- a/clips-frontend/__tests__/lib/auth-security.test.ts
+++ b/clips-frontend/__tests__/lib/auth-security.test.ts
@@ -1,46 +1,56 @@
-/**
- * Jest tests converted from test-auth-security.js (#441)
- * Verifies that passwords are never stored in localStorage via setUser.
- */
+import {
+  persistClipcashUser,
+  clearClipcashUser,
+} from "@/app/lib/authUser";
 
-// Replicate the setUser logic from AuthProvider
-function setUser(newUser: Record<string, unknown> | null) {
-  if (newUser) {
-    const { password, ...safeUser } = newUser;
-    void password; // intentionally stripped
-    localStorage.setItem('clipcash_user', JSON.stringify(safeUser));
-  } else {
-    localStorage.removeItem('clipcash_user');
-  }
-}
-
-describe('AuthProvider password security', () => {
+describe("AuthProvider password security", () => {
   beforeEach(() => localStorage.clear());
 
-  it('strips password field before persisting to localStorage', () => {
-    setUser({ id: '123', email: 'test@example.com', name: 'Test User', password: 'super-secret', onboardingStep: 1, profile: {} });
-    const stored = JSON.parse(localStorage.getItem('clipcash_user')!);
-    expect(stored).not.toHaveProperty('password');
+  it("strips password field before persisting to localStorage", () => {
+    persistClipcashUser({
+      id: "123",
+      email: "test@example.com",
+      name: "Test User",
+      onboardingStep: 1,
+      profile: {},
+      password: "super-secret",
+    } as never);
+
+    const stored = JSON.parse(localStorage.getItem("clipcash_user")!);
+    expect(stored).not.toHaveProperty("password");
   });
 
-  it('preserves all non-sensitive fields', () => {
-    setUser({ id: '123', email: 'test@example.com', name: 'Test User', password: 'secret', onboardingStep: 1, profile: {} });
-    const stored = JSON.parse(localStorage.getItem('clipcash_user')!);
-    expect(stored.id).toBe('123');
-    expect(stored.email).toBe('test@example.com');
+  it("preserves all non-sensitive fields", () => {
+    persistClipcashUser({
+      id: "123",
+      email: "test@example.com",
+      name: "Test User",
+      onboardingStep: 1,
+      profile: {},
+    });
+
+    const stored = JSON.parse(localStorage.getItem("clipcash_user")!);
+    expect(stored.id).toBe("123");
+    expect(stored.email).toBe("test@example.com");
     expect(stored.onboardingStep).toBe(1);
   });
 
-  it('works correctly when user has no password field', () => {
-    setUser({ id: '456', email: 'user@example.com', profile: { username: 'testuser' } });
-    const stored = JSON.parse(localStorage.getItem('clipcash_user')!);
-    expect(stored).not.toHaveProperty('password');
-    expect(stored.profile.username).toBe('testuser');
+  it("works correctly when user has no password field", () => {
+    persistClipcashUser({
+      id: "456",
+      email: "user@example.com",
+      onboardingStep: 0,
+      profile: { username: "testuser" },
+    });
+
+    const stored = JSON.parse(localStorage.getItem("clipcash_user")!);
+    expect(stored).not.toHaveProperty("password");
+    expect(stored.profile.username).toBe("testuser");
   });
 
-  it('clears localStorage on logout (null user)', () => {
-    setUser({ id: '123', email: 'test@example.com' });
-    setUser(null);
-    expect(localStorage.getItem('clipcash_user')).toBeNull();
+  it("clears localStorage on logout (null user)", () => {
+    persistClipcashUser({ id: "123", email: "test@example.com", onboardingStep: 0 });
+    clearClipcashUser();
+    expect(localStorage.getItem("clipcash_user")).toBeNull();
   });
 });

--- a/clips-frontend/__tests__/lib/auth.test.ts
+++ b/clips-frontend/__tests__/lib/auth.test.ts
@@ -1,0 +1,68 @@
+import { jwtCallback, sessionCallback } from "@/app/lib/authCallbacks";
+import { DEFAULT_ONBOARDING_STEP } from "@/app/lib/mockApi";
+
+describe("session callback", () => {
+  it("uses onboardingStep from the token", async () => {
+    const result = await sessionCallback({
+      session: {
+        user: { email: "test@example.com", name: "Test User" },
+        expires: "2099-01-01",
+      },
+      token: { onboardingStep: 3 },
+    });
+
+    expect((result.user as { onboardingStep: number }).onboardingStep).toBe(3);
+  });
+
+  it("loads onboardingStep from the user profile when missing on token", async () => {
+    const result = await sessionCallback({
+      session: {
+        user: { email: "test@example.com", name: "Test User" },
+        expires: "2099-01-01",
+      },
+      token: {},
+    });
+
+    expect((result.user as { onboardingStep: number }).onboardingStep).toBe(3);
+  });
+
+  it("uses the default onboarding step for unknown users", async () => {
+    const result = await sessionCallback({
+      session: {
+        user: { email: "unknown@example.com", name: "Unknown" },
+        expires: "2099-01-01",
+      },
+      token: {},
+    });
+
+    expect((result.user as { onboardingStep: number }).onboardingStep).toBe(
+      DEFAULT_ONBOARDING_STEP
+    );
+  });
+
+  it("does not derive onboarding from email substrings", async () => {
+    const result = await sessionCallback({
+      session: {
+        user: { email: "brandnew@example.com", name: "New User" },
+        expires: "2099-01-01",
+      },
+      token: { onboardingStep: DEFAULT_ONBOARDING_STEP },
+    });
+
+    expect((result.user as { onboardingStep: number }).onboardingStep).toBe(
+      DEFAULT_ONBOARDING_STEP
+    );
+  });
+});
+
+describe("jwt callback", () => {
+  it("stores onboardingStep from the user profile", async () => {
+    const token = await jwtCallback({
+      token: { email: "test@example.com" },
+      user: { email: "test@example.com", id: "test-user-id" },
+      account: null,
+    });
+
+    expect(token.onboardingStep).toBe(3);
+  });
+});

--- a/clips-frontend/__tests__/lib/authRedirect.test.ts
+++ b/clips-frontend/__tests__/lib/authRedirect.test.ts
@@ -1,0 +1,70 @@
+import { getAuthRedirectTarget } from "@/app/lib/authRedirect";
+import type { User } from "@/app/lib/mockApi";
+
+const baseUser: User = {
+  id: "1",
+  email: "user@example.com",
+  onboardingStep: 3,
+};
+
+describe("getAuthRedirectTarget", () => {
+  it("returns null while auth is loading", () => {
+    expect(
+      getAuthRedirectTarget({
+        pathname: "/dashboard",
+        user: baseUser,
+        isAuthReady: false,
+      })
+    ).toBeNull();
+  });
+
+  it("redirects unauthenticated users away from protected routes", () => {
+    expect(
+      getAuthRedirectTarget({
+        pathname: "/dashboard",
+        user: null,
+        isAuthReady: true,
+      })
+    ).toBe("/login");
+  });
+
+  it("redirects authenticated users on auth routes to the dashboard", () => {
+    expect(
+      getAuthRedirectTarget({
+        pathname: "/login",
+        user: baseUser,
+        isAuthReady: true,
+      })
+    ).toBe("/dashboard");
+  });
+
+  it("redirects incomplete onboarding users to onboarding", () => {
+    expect(
+      getAuthRedirectTarget({
+        pathname: "/login",
+        user: { ...baseUser, onboardingStep: 1 },
+        isAuthReady: true,
+      })
+    ).toBe("/onboarding");
+  });
+
+  it("redirects completed users away from onboarding", () => {
+    expect(
+      getAuthRedirectTarget({
+        pathname: "/onboarding",
+        user: baseUser,
+        isAuthReady: true,
+      })
+    ).toBe("/dashboard");
+  });
+
+  it("does not redirect when already on the target route", () => {
+    expect(
+      getAuthRedirectTarget({
+        pathname: "/dashboard",
+        user: baseUser,
+        isAuthReady: true,
+      })
+    ).toBeNull();
+  });
+});

--- a/clips-frontend/app/lib/auth.ts
+++ b/clips-frontend/app/lib/auth.ts
@@ -3,6 +3,7 @@ import GoogleProvider from "next-auth/providers/google";
 import AppleProvider from "next-auth/providers/apple";
 import TwitterProvider from "next-auth/providers/twitter";
 import InstagramProvider from "next-auth/providers/instagram";
+import { jwtCallback, sessionCallback } from "./authCallbacks";
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -59,25 +60,8 @@ export const authOptions: NextAuthOptions = {
     },
   ],
   callbacks: {
-    async jwt({ token, account, profile }) {
-      if (account) {
-        token.accessToken = account.access_token;
-        token.provider = account.provider;
-        if (profile) {
-          token.profile = profile;
-        }
-      }
-      return token;
-    },
-    async session({ session, token }) {
-      if (session.user) {
-        (session.user as any).onboardingStep = session.user.email?.includes("new") ? 1 : 3;
-        (session.user as any).accessToken = token.accessToken;
-        (session.user as any).provider = token.provider;
-        (session.user as any).profile = token.profile;
-      }
-      return session;
-    },
+    jwt: jwtCallback,
+    session: sessionCallback,
   },
   pages: {
     signIn: "/login",

--- a/clips-frontend/app/lib/authCallbacks.ts
+++ b/clips-frontend/app/lib/authCallbacks.ts
@@ -1,0 +1,59 @@
+import type { Account, Profile, Session, User } from "next-auth";
+import type { JWT } from "next-auth/jwt";
+import {
+  DEFAULT_ONBOARDING_STEP,
+  getOnboardingStepForEmail,
+} from "./mockApi";
+
+export async function jwtCallback({
+  token,
+  account,
+  profile,
+  user,
+}: {
+  token: JWT;
+  account: Account | null;
+  profile?: Profile;
+  user?: User;
+}): Promise<JWT> {
+  if (account) {
+    token.accessToken = account.access_token;
+    token.provider = account.provider;
+    if (profile) {
+      token.profile = profile;
+    }
+  }
+  const email = user?.email ?? (token.email as string | undefined);
+  if (email) {
+    token.onboardingStep = getOnboardingStepForEmail(email);
+  }
+  return token;
+}
+
+export async function sessionCallback({
+  session,
+  token,
+}: {
+  session: Session;
+  token: JWT;
+}): Promise<Session> {
+  if (session.user) {
+    const onboardingStep =
+      typeof token.onboardingStep === "number"
+        ? token.onboardingStep
+        : getOnboardingStepForEmail(session.user.email);
+
+    (session.user as { onboardingStep: number }).onboardingStep =
+      onboardingStep ?? DEFAULT_ONBOARDING_STEP;
+    (session.user as { accessToken?: string }).accessToken = token.accessToken as
+      | string
+      | undefined;
+    (session.user as { provider?: string }).provider = token.provider as
+      | string
+      | undefined;
+    (session.user as { profile?: Profile }).profile = token.profile as
+      | Profile
+      | undefined;
+  }
+  return session;
+}

--- a/clips-frontend/app/lib/authRedirect.ts
+++ b/clips-frontend/app/lib/authRedirect.ts
@@ -1,0 +1,54 @@
+import type { User } from "./mockApi";
+
+const PROTECTED_ROUTES = [
+  "/dashboard",
+  "/onboarding",
+  "/earnings",
+  "/projects",
+  "/vault",
+  "/platforms",
+  "/clips",
+];
+
+export function isProtectedRoute(pathname: string): boolean {
+  return PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+}
+
+export function isAuthRoute(pathname: string): boolean {
+  return pathname === "/login" || pathname === "/signup";
+}
+
+export type AuthRedirectInput = {
+  pathname: string;
+  user: User | null;
+  isAuthReady: boolean;
+};
+
+export function getAuthRedirectTarget({
+  pathname,
+  user,
+  isAuthReady,
+}: AuthRedirectInput): string | null {
+  if (!isAuthReady) return null;
+
+  const authenticated = !!user;
+  const protectedRoute = isProtectedRoute(pathname);
+  const authRoute = isAuthRoute(pathname);
+
+  if (!authenticated && protectedRoute) {
+    return "/login";
+  }
+
+  if (authenticated && (authRoute || pathname === "/")) {
+    if (user.onboardingStep === 1 || user.onboardingStep === 2) {
+      return "/onboarding";
+    }
+    return "/dashboard";
+  }
+
+  if (authenticated && pathname === "/onboarding" && user.onboardingStep > 2) {
+    return "/dashboard";
+  }
+
+  return null;
+}

--- a/clips-frontend/app/lib/authUser.ts
+++ b/clips-frontend/app/lib/authUser.ts
@@ -1,0 +1,35 @@
+import type { Session } from "next-auth";
+import type { User } from "./mockApi";
+import { DEFAULT_ONBOARDING_STEP } from "./mockApi";
+
+const CLIPCASH_USER_KEY = "clipcash_user";
+
+export function mapSessionToUser(session: Session): User {
+  const sessionUser = session.user as {
+    id?: string;
+    email?: string | null;
+    name?: string | null;
+    onboardingStep?: number;
+    profile?: User["profile"];
+  };
+
+  return {
+    id: sessionUser.id ?? sessionUser.email ?? "",
+    email: sessionUser.email ?? "",
+    name: sessionUser.name ?? undefined,
+    onboardingStep: sessionUser.onboardingStep ?? DEFAULT_ONBOARDING_STEP,
+    profile: sessionUser.profile ?? {},
+  };
+}
+
+export function persistClipcashUser(user: User & { password?: string }): void {
+  if (typeof window === "undefined") return;
+  const { password: _password, ...safeUser } = user;
+  void _password;
+  localStorage.setItem(CLIPCASH_USER_KEY, JSON.stringify(safeUser));
+}
+
+export function clearClipcashUser(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(CLIPCASH_USER_KEY);
+}

--- a/clips-frontend/app/lib/mockApi.ts
+++ b/clips-frontend/app/lib/mockApi.ts
@@ -20,6 +20,14 @@ export type User = {
   encryptedWalletBackup?: string;
 };
 
+export const DEFAULT_ONBOARDING_STEP = 0;
+
+export function getOnboardingStepForEmail(email: string | null | undefined): number {
+  if (!email) return DEFAULT_ONBOARDING_STEP;
+  const user = users.find((u) => u.email === email);
+  return user?.onboardingStep ?? DEFAULT_ONBOARDING_STEP;
+}
+
 // In-memory fake database
 const users: User[] = [
   {

--- a/clips-frontend/app/platforms/page.tsx
+++ b/clips-frontend/app/platforms/page.tsx
@@ -83,7 +83,7 @@ const MetaMaskIcon = ({ className }: { className?: string }) => (
 /* ================= PAGE ================= */
 
 export default function PlatformsPage() {
-  const { user, isLoading: authLoading } = useAuth();
+  const { isLoading: authLoading } = useAuth();
   const { data: session, status: sessionStatus } = useSession();
   const { showToast } = useToast();
 

--- a/clips-frontend/components/AuthProvider.tsx
+++ b/clips-frontend/components/AuthProvider.tsx
@@ -1,10 +1,23 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+} from "react";
 import { User } from "../app/lib/mockApi";
 import { useRouter, usePathname } from "next/navigation";
 import { useUserStore, useDashboardStore, useEarningsStore } from "@/app/store";
 import { useSession, signOut } from "next-auth/react";
+import { getAuthRedirectTarget } from "@/app/lib/authRedirect";
+import {
+  mapSessionToUser,
+  persistClipcashUser,
+  clearClipcashUser,
+} from "@/app/lib/authUser";
 
 interface AuthContextType {
   user: User | null;
@@ -22,125 +35,117 @@ const AuthContext = createContext<AuthContextType>({
 
 export const useAuth = () => useContext(AuthContext);
 
+type AuthSource = "session" | "mock" | null;
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUserState] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const authSourceRef = useRef<AuthSource>(null);
+  const syncedSessionEmailRef = useRef<string | null>(null);
+  const pendingRedirectRef = useRef<string | null>(null);
   const router = useRouter();
   const pathname = usePathname();
   const setProfile = useUserStore((state) => state.setProfile);
   const clearUser = useUserStore((state) => state.clearUser);
   const { data: session, status } = useSession();
 
-  // Load initial auth state on mount
-  useEffect(() => {
-    const stored = localStorage.getItem("clipcash_user");
-    if (stored) {
-      try {
-        const parsed = JSON.parse(stored);
-        setUserState(parsed);
-      } catch (e) {
-        console.error("Failed to parse stored user", e);
-      }
-    }
-    setIsLoading(false);
-  }, []);
-
-  useEffect(() => {
-    if (isLoading) return;
-
-  const protectedRoutes = [
-    "/dashboard",
-    "/onboarding",
-    "/earnings",
-    "/projects",
-    "/vault",
-    "/platforms",
-    "/clips",
-  ];
-
-  const isProtectedRoute = protectedRoutes.some(route =>
-    pathname.startsWith(route)
-  );
-
-  const isAuthRoute = pathname === "/login" || pathname === "/signup";
-
-  // 🔐 Not logged in → block protected pages
-  if (!user && isProtectedRoute) {
-    router.push("/login");
-    return;
-  }
-
-  // 🔓 Logged in → prevent going back to auth pages
-  if (user && isAuthRoute) {
-    if (user.onboardingStep === 1 || user.onboardingStep === 2) {
-      router.push("/onboarding");
-    } else {
-      router.push("/dashboard");
-    }
-    return;
-  }
-
-  // 🚫 Prevent accessing onboarding after completion
-  if (user && pathname === "/onboarding" && user.onboardingStep > 2) {
-    router.push("/dashboard");
-  }
-
-}, [user, isLoading, pathname, router]);
-
-  const setUser = (newUser: User | null) => {
-    setUserState(newUser);
-    if (newUser) {
-      localStorage.setItem("clipcash_user", JSON.stringify(newUser));
-      // Sync the authenticated user to useUserStore
-      const userProfile = {
-        id: newUser.id,
-        name: newUser.name || newUser.username || "User",
-        email: newUser.email,
+  const syncUserProfile = useCallback(
+    (nextUser: User) => {
+      setProfile({
+        id: nextUser.id,
+        name: nextUser.name || nextUser.username || "User",
+        email: nextUser.email,
         avatarUrl: null,
         plan: "pro" as const,
         planUsagePercent: 80,
-      };
-      setProfile(userProfile);
-      // Kick off background prefetch so data is ready when user lands on dashboard/earnings
+      });
       useDashboardStore.getState().fetchDashboard();
       useEarningsStore.getState().fetchEarnings();
+    },
+    [setProfile]
+  );
+
+  const clearAuthState = useCallback(() => {
+    authSourceRef.current = null;
+    syncedSessionEmailRef.current = null;
+    setUserState(null);
+    clearClipcashUser();
+    clearUser();
+  }, [clearUser]);
+
+  useEffect(() => {
+    if (status === "loading") {
+      setIsLoading(true);
+      return;
+    }
+
+    if (status === "authenticated" && session?.user?.email) {
+      const sessionEmail = session.user.email;
+      if (
+        authSourceRef.current !== "session" ||
+        syncedSessionEmailRef.current !== sessionEmail
+      ) {
+        authSourceRef.current = "session";
+        syncedSessionEmailRef.current = sessionEmail;
+        const nextUser = mapSessionToUser(session);
+        setUserState(nextUser);
+        persistClipcashUser(nextUser);
+        syncUserProfile(nextUser);
+      }
+      setIsLoading(false);
+      return;
+    }
+
+    if (status === "unauthenticated") {
+      syncedSessionEmailRef.current = null;
+      if (authSourceRef.current === "session") {
+        clearAuthState();
+      }
+    }
+
+    setIsLoading(false);
+  }, [session, status, clearAuthState, syncUserProfile]);
+
+  useEffect(() => {
+    const redirectTo = getAuthRedirectTarget({
+      pathname,
+      user,
+      isAuthReady: !isLoading && status !== "loading",
+    });
+
+    if (!redirectTo || redirectTo === pathname) {
+      pendingRedirectRef.current = null;
+      return;
+    }
+
+    if (pendingRedirectRef.current === redirectTo) {
+      return;
+    }
+
+    pendingRedirectRef.current = redirectTo;
+    router.push(redirectTo);
+  }, [user, isLoading, status, pathname, router]);
+
+  const setUser = (newUser: User | null) => {
+    if (newUser) {
+      const { password: _password, ...safeUser } = newUser as User & {
+        password?: string;
+      };
+      void _password;
+      authSourceRef.current = "mock";
+      syncedSessionEmailRef.current = null;
+      setUserState(safeUser as User);
+      persistClipcashUser(safeUser as User);
+      syncUserProfile(safeUser as User);
     } else {
-      localStorage.removeItem("clipcash_user");
-      clearUser();
+      clearAuthState();
     }
   };
 
   const logout = () => {
     signOut({ callbackUrl: "/login" });
-    setUser(null);
+    clearAuthState();
   };
-
-  // Basic routing logic based on auth state
-  useEffect(() => {
-    if (isLoading || status === "loading") return;
-
-    const protectedRoutes = ["/dashboard", "/onboarding", "/earnings", "/projects", "/vault", "/platforms", "/clips"];
-    const isProtectedRoute = protectedRoutes.some(route => pathname.startsWith(route));
-    const isAuthRoute = pathname === "/login" || pathname === "/signup";
-
-    if (user || session) {
-      if (isAuthRoute || pathname === "/") {
-        if (user?.onboardingStep === 1 || user?.onboardingStep === 2) {
-          router.push("/onboarding");
-        } else {
-          router.push("/dashboard");
-        }
-      } else if (pathname === "/onboarding") {
-        if (user?.onboardingStep && user.onboardingStep > 2) {
-          router.push("/dashboard");
-        }
-      }
-    } else {
-      if (isProtectedRoute) {
-        router.push("/login");
-      }
-    }
-  }, [user, session, isLoading, status, pathname, router]);
 
   return (
     <AuthContext.Provider value={{ user, setUser, logout, isLoading }}>

--- a/clips-frontend/components/WalletProvider.tsx
+++ b/clips-frontend/components/WalletProvider.tsx
@@ -179,34 +179,37 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
   // Restore persisted session on mount
   useEffect(() => {
-    secureStorage
-      .getItem(STORAGE_KEY)
-      .then((stored) => {
+    async function restoreSession() {
+      try {
+        const stored = await secureStorage.getItem(STORAGE_KEY);
         if (stored) {
-          const parsed = JSON.parse(stored);
-          if (parsed.address && parsed.walletType) {
-            setState((prev: WalletState) => ({
-              ...prev,
-              address: parsed.address!,
-              chainId: parsed.chainId ?? null,
-              walletType: parsed.walletType!,
-              isConnected: true,
-            }));
-            if (parsed.walletType === "stellar") {
-              setStellarSecret(parsed.stellarSecret ?? null);
-              setStellarMnemonic(parsed.stellarMnemonic ?? null);
+          try {
+            const parsed = JSON.parse(stored);
+            if (parsed.address && parsed.walletType) {
+              setState((prev: WalletState) => ({
+                ...prev,
+                address: parsed.address!,
+                chainId: parsed.chainId ?? null,
+                walletType: parsed.walletType!,
+                isConnected: true,
+              }));
+              if (parsed.walletType === "stellar") {
+                setStellarSecret(parsed.stellarSecret ?? null);
+                setStellarMnemonic(parsed.stellarMnemonic ?? null);
+              }
             }
+          } catch {
+            await secureStorage.removeItem(STORAGE_KEY);
           }
         }
+      } catch {
+        await secureStorage.removeItem(STORAGE_KEY);
+      } finally {
         setState((prev: WalletState) => ({ ...prev, isRestoringSession: false }));
-      })
-      .catch(() => {
-        setState((prev: WalletState) => ({ ...prev, isRestoringSession: false }));
-      });
-    } catch {
-      // Malformed JSON — clear it
-      sessionStorage.removeItem(STORAGE_KEY);
+      }
     }
+
+    void restoreSession();
   }, []);
 
   // Balance updater helper


### PR DESCRIPTION
## Summary

This PR addresses four related auth and wallet issues in a single changeset:

1. **Onboarding step** — Removes the email-substring mock (`email.includes("new")`) and loads `onboardingStep` from the user profile (mock DB via `getOnboardingStepForEmail`), with a default of `0` when no profile exists.

2. **Auth state reconciliation** — Makes the NextAuth session the source of truth for OAuth users. `clipcash_user` in `localStorage` is a cache only (written on login, cleared on session expiry). Email/password login via `MockApi` still uses `setUser` without conflicting with OAuth session lifecycle.

3. **Redirect race conditions** — Merges duplicate routing `useEffect` blocks into one effect backed by `getAuthRedirectTarget()`, with deduplication to prevent double redirects on login, logout, or refresh.

4. **WalletProvider compile error** — Removes the orphaned `catch` after a promise chain and wraps session restoration in a proper `async` `try/catch/finally` using `secureStorage`.

## Changes

| Area | Files |
|------|--------|
| Onboarding / NextAuth callbacks | `clips-frontend/app/lib/authCallbacks.ts`, `clips-frontend/app/lib/auth.ts`, `clips-frontend/app/lib/mockApi.ts` |
| Auth sync & redirects | `clips-frontend/components/AuthProvider.tsx`, `clips-frontend/app/lib/authUser.ts`, `clips-frontend/app/lib/authRedirect.ts` |
| Wallet session restore | `clips-frontend/components/WalletProvider.tsx` |
| Platforms page | `clips-frontend/app/platforms/page.tsx` |
| Tests | `clips-frontend/__tests__/lib/auth.test.ts`, `clips-frontend/__tests__/lib/authRedirect.test.ts`, `clips-frontend/__tests__/components/AuthProvider.test.tsx`, `clips-frontend/__tests__/lib/auth-security.test.ts` |

## Issue checklist

### Onboarding step from profile

- [x] `onboardingStep` fetched from user profile, not derived from email
- [x] Hardcoded email mock removed
- [x] Fallback default (`DEFAULT_ONBOARDING_STEP = 0`) when user not found
- [x] Session callback covered by unit tests

### Single source of truth for auth

- [x] NextAuth session drives OAuth user state
- [x] `clipcash_user` cleared when NextAuth session expires
- [x] `clipcash_user` populated from session on OAuth login
- [x] No independent localStorage read on mount as source of truth
- [x] Tests for session expiry and mock re-login

### Unified redirect logic

- [x] Two routing effects merged into one
- [x] Redirect deduplication to avoid double `router.push`
- [x] Unit tests for authenticated, unauthenticated, and loading paths

### WalletProvider try/catch

- [x] Orphaned `catch` removed
- [x] Session restoration in proper `try/catch/finally`
- [x] Malformed persisted data clears `secureStorage` key

## How to test

```bash
cd clips-frontend
npm install
npm test -- __tests__/lib/auth.test.ts __tests__/lib/authRedirect.test.ts __tests__/lib/auth-security.test.ts __tests__/components/AuthProvider.test.tsx
npm run test:e2e -- tests/e2e/login.test.ts
```

**Manual checks:**

- Sign up with a new email → should land on `/onboarding` (step `1` from mock signup), not based on `"new"` in the address.
- Log in as `test@example.com` → onboarding step `3` from profile.
- OAuth login → `localStorage` contains synced user; sign out / session expiry → `clipcash_user` removed.
- Connect MetaMask / refresh page → wallet state restores.
- Login → no double redirect flicker between `/login` and `/dashboard`.

## Notes

- `npm run build` may still fail on upstream due to a pre-existing `@/lib/analytics` import path issue (`app/lib/analytics.ts` vs `@/lib/analytics`). That is unrelated to this PR; the WalletProvider TypeScript syntax error is fixed here.





closes #423 
closes #422 
closes #420 
closes #421 
