### PR TITLE
Handle Soroban stubs, auth tests, Sentry breadcrumbs, and social reco…

### DIFF
--- a/clips-frontend/.gitignore
+++ b/clips-frontend/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.npm-cache
 /.pnp
 .pnp.*
 .yarn/*

--- a/clips-frontend/SECURITY.md
+++ b/clips-frontend/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Model
+
+## Social wallet recovery
+
+Social recovery protects a Stellar wallet backup using:
+
+1. **Password-based encryption (client-side)** — The mnemonic or secret key is encrypted with AES-GCM (PBKDF2-derived key) before any sharing. The recovery password is never sent to the server.
+
+2. **Shamir secret sharing (t-of-n)** — The encrypted backup is split into `n` shares with threshold `t`. Each guardian receives one share by email invitation. No single guardian or the server stores the full encrypted backup.
+
+3. **Guardian approval** — Recovery sessions require at least `t` guardians to approve before shares are combined. The combined ciphertext is returned only when the threshold is met.
+
+4. **Final decryption** — The account owner supplies the recovery password locally to decrypt the restored ciphertext.
+
+### Mock vs production
+
+| Component | Current (mock API) | Production requirement |
+| --- | --- | --- |
+| Share storage | In-memory `guardianShares` map | Encrypted at rest; guardian-authenticated retrieval |
+| Email invitations | `console.info` via `sendGuardianInvitation` | Transactional email (SES, SendGrid, etc.) with signed approval links |
+| Guardian approval | Simulated in UI | Authenticated guardian endpoints + audit log |
+
+## Error monitoring (Sentry)
+
+Wallet and Stellar errors sent to Sentry use `beforeSend` and `beforeBreadcrumb` hooks with shared redaction in `app/lib/sentryRedaction.ts`. Secret keys, mnemonics, and similar fields are never included in events or breadcrumbs.
+
+## Soroban smart contracts
+
+`invoke_contract` operations are not supported in the Horizon batch builder. See `SOROBAN_SMART_WALLET_SPIKE.md` for the planned Soroban RPC integration.

--- a/clips-frontend/__tests__/components/AuthProvider.test.tsx
+++ b/clips-frontend/__tests__/components/AuthProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, waitFor, act } from "@testing-library/react";
 import { AuthProvider, useAuth } from "@/components/AuthProvider";
-import { useSession } from "next-auth/react";
+import { useSession, signOut } from "next-auth/react";
 import { useRouter, usePathname } from "next/navigation";
 
 jest.mock("next-auth/react", () => ({
@@ -83,7 +83,49 @@ describe("AuthProvider", () => {
     });
   });
 
-  it("clears localStorage when the NextAuth session expires", async () => {
+  it("does not redirect while session status is loading", async () => {
+    (useSession as jest.Mock).mockReturnValue({
+      data: null,
+      status: "loading",
+    });
+    (usePathname as jest.Mock).mockReturnValue("/dashboard");
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows authenticated users through protected routes", async () => {
+    (useSession as jest.Mock).mockReturnValue({
+      data: {
+        user: {
+          email: "oauth@example.com",
+          name: "OAuth User",
+          onboardingStep: 3,
+        },
+      },
+      status: "authenticated",
+    });
+    (usePathname as jest.Mock).mockReturnValue("/dashboard");
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(push).not.toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("clears localStorage and signs out when the NextAuth session expires", async () => {
     let sessionStatus: "authenticated" | "unauthenticated" = "authenticated";
     let sessionData: { user: { email: string; name: string; onboardingStep: number } } | null =
       {
@@ -120,6 +162,7 @@ describe("AuthProvider", () => {
 
     await waitFor(() => {
       expect(localStorage.getItem("clipcash_user")).toBeNull();
+      expect(signOut).toHaveBeenCalledWith({ redirect: false });
     });
   });
 

--- a/clips-frontend/__tests__/lib/sentryBreadcrumbs.test.ts
+++ b/clips-frontend/__tests__/lib/sentryBreadcrumbs.test.ts
@@ -1,0 +1,57 @@
+import { addWalletBreadcrumb } from "@/app/lib/walletErrorTracking";
+import { sanitizeBreadcrumb } from "@/app/lib/sentryRedaction";
+
+const captureException = jest.fn();
+const addBreadcrumb = jest.fn();
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException,
+  captureMessage: jest.fn(),
+  addBreadcrumb,
+  init: jest.fn(),
+}));
+
+describe("Sentry breadcrumb PII redaction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(window, {
+      Sentry: { captureException, addBreadcrumb },
+    });
+  });
+
+  it("does not include key material in wallet error breadcrumbs", () => {
+    const secretKey = "S".repeat(56);
+    const mnemonic = "abandon ".repeat(11) + "about";
+
+    addWalletBreadcrumb("wallet signing failed", "wallet", {
+      secretKey,
+      mnemonic,
+      private_key: "private-key-value",
+    });
+
+    expect(addBreadcrumb).toHaveBeenCalled();
+    const payload = addBreadcrumb.mock.calls[0][0];
+    expect(payload.data.secretKey).toBe("[REDACTED]");
+    expect(payload.data.mnemonic).toBe("[REDACTED]");
+    expect(payload.data.private_key).toBe("[REDACTED]");
+    expect(payload.data.secretKey).not.toContain(secretKey);
+    expect(payload.data.mnemonic).not.toContain("abandon");
+  });
+
+  it("beforeBreadcrumb-style sanitizer redacts nested wallet fields", () => {
+    const sanitized = sanitizeBreadcrumb({
+      category: "wallet",
+      message: "test",
+      data: {
+        public_key: "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEF",
+        secret_key: "super-secret",
+      },
+    });
+
+    expect(sanitized.data?.secret_key).toBe("[REDACTED]");
+    expect(sanitized.data?.public_key).toMatch(/\.\.\./);
+    expect(sanitized.data?.public_key).not.toBe(
+      "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEF"
+    );
+  });
+});

--- a/clips-frontend/__tests__/lib/shamirRecovery.test.ts
+++ b/clips-frontend/__tests__/lib/shamirRecovery.test.ts
@@ -1,0 +1,20 @@
+import { combineShares, splitSecret } from "@/app/lib/shamirRecovery";
+
+describe("shamirRecovery", () => {
+  it("splits and recombines a secret with threshold t-of-n", () => {
+    const secret = "encrypted-wallet-backup-payload";
+    const shares = splitSecret(secret, { shares: 3, threshold: 2 });
+    expect(shares).toHaveLength(3);
+    expect(shares[0].length).toBeGreaterThan(0);
+
+    const restored = combineShares([shares[0], shares[2]]);
+    expect(restored).toBe(secret);
+  });
+
+  it("requires at least threshold shares to reconstruct", () => {
+    const secret = "another-secret";
+    const shares = splitSecret(secret, { shares: 4, threshold: 3 });
+    const restored = combineShares([shares[0], shares[1], shares[3]]);
+    expect(restored).toBe(secret);
+  });
+});

--- a/clips-frontend/__tests__/lib/stellarInvokeContract.test.ts
+++ b/clips-frontend/__tests__/lib/stellarInvokeContract.test.ts
@@ -1,0 +1,51 @@
+import {
+  createInvokeContractOp,
+  invokeContractBuildError,
+  INVOKE_CONTRACT_USER_MESSAGE,
+  isInvokeContractBuildError,
+} from "@/app/lib/stellarOperations";
+import { buildBatchTransaction } from "@/app/lib/stellar";
+
+jest.mock("@/app/lib/sentry", () => ({
+  captureSorobanNotSupportedWarning: jest.fn(),
+}));
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    Horizon: {
+      Server: jest.fn().mockImplementation(() => ({
+        loadAccount: jest.fn().mockResolvedValue({
+          accountId: () => "GTEST123456789",
+          sequenceNumber: () => "1",
+        }),
+        fetchBaseFee: jest.fn().mockResolvedValue(100),
+      })),
+    },
+  };
+});
+
+describe("invoke_contract", () => {
+  it("returns a typed error result instead of throwing", () => {
+    const error = invokeContractBuildError();
+    expect(error.code).toBe("INVOKE_CONTRACT_NOT_SUPPORTED");
+    expect(error.message).toBe(INVOKE_CONTRACT_USER_MESSAGE);
+    expect(isInvokeContractBuildError(error)).toBe(true);
+  });
+
+  it("buildBatchTransaction returns ok:false for invoke_contract operations", async () => {
+    const result = await buildBatchTransaction("GTEST123456789", [
+      createInvokeContractOp({
+        contractId: "CABC123",
+        method: "transfer",
+      }),
+    ]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe(INVOKE_CONTRACT_USER_MESSAGE);
+      expect(result.operationIndex).toBe(0);
+    }
+  });
+});

--- a/clips-frontend/app/hooks/useStellarTransaction.test.ts
+++ b/clips-frontend/app/hooks/useStellarTransaction.test.ts
@@ -1,6 +1,10 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useStellarTransaction } from "./useStellarTransaction";
 
+jest.mock("@/app/lib/sentry", () => ({
+  captureSorobanNotSupportedWarning: jest.fn(),
+}));
+
 // Mock Freighter wallet
 const mockFreighter = {
   isConnected: jest.fn(),
@@ -369,6 +373,8 @@ import {
   createPaymentOp,
   createChangeTrustOp,
   createManageSellOfferOp,
+  createInvokeContractOp,
+  INVOKE_CONTRACT_USER_MESSAGE,
 } from "../lib/stellarOperations";
 
 describe("useStellarTransaction — batch operations", () => {
@@ -697,6 +703,26 @@ describe("useStellarTransaction — batch operations", () => {
 
       expect(result.current.status).toBe("success");
       expect(buildBatch).toHaveBeenCalledWith([trustlineOp, paymentOp]);
+    });
+
+    it("should surface a friendly error for invoke_contract batches", async () => {
+      const { result } = renderHook(() => useStellarTransaction());
+
+      act(() => {
+        result.current.addOperation(
+          createInvokeContractOp({ contractId: "CABC", method: "mint" })
+        );
+      });
+
+      const buildBatch = jest.fn();
+
+      await act(async () => {
+        await result.current.executeBatchTransaction(buildBatch);
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error?.message).toBe(INVOKE_CONTRACT_USER_MESSAGE);
+      expect(buildBatch).not.toHaveBeenCalled();
     });
 
     it("should sign the batch XDR with the correct network", async () => {

--- a/clips-frontend/app/hooks/useStellarTransaction.ts
+++ b/clips-frontend/app/hooks/useStellarTransaction.ts
@@ -2,7 +2,13 @@
 
 import { useState, useCallback, useRef } from "react";
 import type { StellarOperation } from "@/app/lib/stellarOperations";
-import { validateOperations, BatchValidationError } from "@/app/lib/stellarOperations";
+import {
+  validateOperations,
+  BatchValidationError,
+  INVOKE_CONTRACT_USER_MESSAGE,
+  isInvokeContractBuildError,
+} from "@/app/lib/stellarOperations";
+import { captureSorobanNotSupportedWarning } from "@/app/lib/sentry";
 
 /**
  * Stellar transaction status
@@ -353,6 +359,24 @@ export function useStellarTransaction(options: StellarTransactionOptions = {}) {
         onSuccess?.(result);
         return result;
       } catch (err) {
+        if (isInvokeContractBuildError(err)) {
+          captureSorobanNotSupportedWarning({ source: "executeTransaction" });
+          const error: StellarTransactionError = {
+            code: "INVOKE_CONTRACT_NOT_SUPPORTED",
+            message: INVOKE_CONTRACT_USER_MESSAGE,
+          };
+          setState((prev) => ({
+            ...prev,
+            status: "error",
+            isLoading: false,
+            error,
+            result: null,
+            transactionHash: null,
+          }));
+          onError?.(error);
+          return null;
+        }
+
         const error = err as StellarTransactionError;
         setState((prev) => ({
           ...prev,
@@ -500,7 +524,28 @@ export function useStellarTransaction(options: StellarTransactionOptions = {}) {
         return null;
       }
 
-      // Validate before touching the network
+      const invokeContractIndex = currentOps.findIndex(
+        (q) => q.operation.type === "invoke_contract"
+      );
+      if (invokeContractIndex >= 0) {
+        captureSorobanNotSupportedWarning({
+          source: "executeBatchTransaction",
+          operationIndex: invokeContractIndex,
+        });
+        const error: StellarTransactionError = {
+          code: "INVOKE_CONTRACT_NOT_SUPPORTED",
+          message: INVOKE_CONTRACT_USER_MESSAGE,
+        };
+        setState((prev) => ({
+          ...prev,
+          status: "error",
+          isLoading: false,
+          error,
+        }));
+        onError?.(error);
+        return null;
+      }
+
       try {
         validateOperations(currentOps.map((q) => q.operation));
       } catch (err) {

--- a/clips-frontend/app/hooks/useTrustline.ts
+++ b/clips-frontend/app/hooks/useTrustline.ts
@@ -81,9 +81,16 @@ export function useTrustline(options: UseTrustlineOptions = {}) {
         // Build unsigned transaction XDR
         // Stellar memo text is limited to 28 bytes — keep it short
         const memoText = action === "add" ? `Add ${assetCode}` : `Remove ${assetCode}`;
-        const { xdr } = await buildBatchTransaction(publicKey, [op], {
+        const batch = await buildBatchTransaction(publicKey, [op], {
           memo: memoText.slice(0, 28),
         });
+        if (!batch.ok) {
+          throw {
+            code: batch.error.code,
+            message: batch.error.message,
+          } as TrustlineError;
+        }
+        const { xdr } = batch;
 
         let signedXdr: string;
 

--- a/clips-frontend/app/lib/mockApi.ts
+++ b/clips-frontend/app/lib/mockApi.ts
@@ -1,6 +1,7 @@
 // This file replaces the backend server by mocking the needed endpoints client-side with simulated latency.
 
 import { rateLimiter } from './rateLimiter';
+import { combineShares, splitSecret } from "./shamirRecovery";
 import type {
   DashboardStats,
   RevenuePoint,
@@ -23,8 +24,8 @@ export type User = {
   username?: string;
   onboardingStep: number;
   profile?: OnboardingData;
-  guardians?: string[];
-  encryptedWalletBackup?: string;
+  socialRecoveryThreshold?: number;
+  socialRecoveryGuardianCount?: number;
 };
 
 export const DEFAULT_ONBOARDING_STEP = 0;
@@ -45,16 +46,24 @@ const users: User[] = [
     password: "Password123",
     onboardingStep: 3,
     profile: { niche: "gaming", username: "testuser" },
-    guardians: ["guardian1@example.com", "guardian2@example.com", "guardian3@example.com"],
-    encryptedWalletBackup: "abandon ability able about above absent absorb abstract absurd abuse access accident"
+    socialRecoveryThreshold: 2,
+    socialRecoveryGuardianCount: 3,
   }
 ];
 
-// In-memory social recovery sessions
+type StoredRecoveryConfig = {
+  email: string;
+  threshold: number;
+  guardians: { email: string; shareId: string }[];
+};
+
+const recoveryConfigs: Record<string, StoredRecoveryConfig> = {};
+const guardianShares: Record<string, string> = {};
+
 const socialRecoverySessions: Record<string, {
   email: string;
-  guardians: { email: string; approved: boolean }[];
-  recoveryKeyEncrypted: string;
+  threshold: number;
+  guardians: { email: string; approved: boolean; shareId: string }[];
 }> = {};
 
 // Password reset tokens storage
@@ -237,36 +246,95 @@ export const getEarningsReport = rateLimiter(async (userId: string) => {
   };
 }, 10, 10000);
 
-export const saveSocialRecoveryConfig = rateLimiter(async (email: string, guardians: string[], encryptedBackup: string) => {
-  await delay(600);
-  const user = users.find(u => u.email === email);
-  if (!user) throw new Error("User not found");
-  user.guardians = guardians;
-  user.encryptedWalletBackup = encryptedBackup;
-  return { success: true };
-}, 10, 10000);
+export const sendGuardianInvitation = rateLimiter(
+  async (guardianEmail: string, shareId: string, ownerEmail: string) => {
+    await delay(200);
+    if (typeof console !== "undefined" && console.info) {
+      console.info(
+        `[mock-email] Guardian invitation sent to ${guardianEmail} for account ${ownerEmail} (share ${shareId})`
+      );
+    }
+    return { success: true };
+  },
+  20,
+  10000
+);
+
+export const saveSocialRecoveryConfig = rateLimiter(
+  async (
+    email: string,
+    guardians: string[],
+    encryptedBackup: string,
+    threshold: number
+  ) => {
+    await delay(600);
+    const user = users.find((u) => u.email === email);
+    if (!user) throw new Error("User not found");
+    if (threshold < 2 || threshold > guardians.length) {
+      throw new Error("Threshold must be at least 2 and cannot exceed guardian count.");
+    }
+
+    const shares = splitSecret(encryptedBackup, {
+      shares: guardians.length,
+      threshold,
+    });
+
+    const config: StoredRecoveryConfig = {
+      email,
+      threshold,
+      guardians: [],
+    };
+
+    for (let i = 0; i < guardians.length; i++) {
+      const shareId = crypto.randomUUID();
+      guardianShares[shareId] = shares[i];
+      config.guardians.push({ email: guardians[i], shareId });
+      await sendGuardianInvitation(guardians[i], shareId, email);
+    }
+
+    recoveryConfigs[email] = config;
+    user.socialRecoveryThreshold = threshold;
+    user.socialRecoveryGuardianCount = guardians.length;
+
+    return { success: true, threshold, guardianCount: guardians.length };
+  },
+  10,
+  10000
+);
 
 export const initiateSocialRecovery = rateLimiter(async (email: string) => {
   await delay(800);
-  const user = users.find(u => u.email === email);
+  const user = users.find((u) => u.email === email);
   if (!user) throw new Error("User not found");
-  if (!user.guardians || user.guardians.length === 0) {
+  const config = recoveryConfigs[email];
+  if (!config || config.guardians.length === 0) {
     throw new Error("No guardians configured for this account. Use mnemonic recovery instead.");
   }
+
   const sessionId = crypto.randomUUID();
   socialRecoverySessions[sessionId] = {
     email,
-    guardians: user.guardians.map(g => ({ email: g, approved: false })),
-    recoveryKeyEncrypted: user.encryptedWalletBackup || ""
+    threshold: config.threshold,
+    guardians: config.guardians.map((g) => ({
+      email: g.email,
+      approved: false,
+      shareId: g.shareId,
+    })),
   };
-  return { sessionId, guardians: user.guardians };
+
+  return {
+    sessionId,
+    guardians: config.guardians.map((g) => g.email),
+    threshold: config.threshold,
+    guardianCount: config.guardians.length,
+  };
 }, 10, 10000);
 
 export const approveGuardian = rateLimiter(async (sessionId: string, guardianEmail: string) => {
   await delay(400);
   const session = socialRecoverySessions[sessionId];
   if (!session) throw new Error("Invalid or expired session");
-  const guardian = session.guardians.find(g => g.email === guardianEmail);
+  const guardian = session.guardians.find((g) => g.email === guardianEmail);
   if (!guardian) throw new Error("Guardian not found in this session");
   guardian.approved = true;
   return { success: true, guardians: session.guardians };
@@ -276,16 +344,30 @@ export const checkSocialRecovery = rateLimiter(async (sessionId: string) => {
   await delay(600);
   const session = socialRecoverySessions[sessionId];
   if (!session) throw new Error("Invalid or expired session");
-  const approvedCount = session.guardians.filter(g => g.approved).length;
+  const approvedGuardians = session.guardians.filter((g) => g.approved);
+  const approvedCount = approvedGuardians.length;
   const totalCount = session.guardians.length;
-  const isRecoverable = approvedCount >= Math.ceil(totalCount / 2);
+  const isRecoverable = approvedCount >= session.threshold;
+
+  let encryptedBackup: string | null = null;
+  if (isRecoverable) {
+    const shareValues = approvedGuardians
+      .slice(0, session.threshold)
+      .map((g) => guardianShares[g.shareId])
+      .filter(Boolean);
+    if (shareValues.length >= session.threshold) {
+      encryptedBackup = combineShares(shareValues.slice(0, session.threshold));
+    }
+  }
+
   return {
     success: true,
     isRecoverable,
     approvedCount,
     totalCount,
+    threshold: session.threshold,
     guardians: session.guardians,
-    encryptedBackup: isRecoverable ? session.recoveryKeyEncrypted : null
+    encryptedBackup,
   };
 }, 20, 10000);
 
@@ -301,6 +383,7 @@ export const MockApi = {
   saveOnboarding,
   getEarningsReport,
   saveSocialRecoveryConfig,
+  sendGuardianInvitation,
   initiateSocialRecovery,
   approveGuardian,
   checkSocialRecovery,

--- a/clips-frontend/app/lib/sentry.ts
+++ b/clips-frontend/app/lib/sentry.ts
@@ -7,6 +7,16 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { useAuth } from "@/components/AuthProvider";
+import {
+  redactAddress,
+  redactEmail,
+  sanitizeBreadcrumbPayload,
+  sanitizeSentryContexts,
+} from "@/app/lib/sentryRedaction";
+import {
+  INVOKE_CONTRACT_NOT_SUPPORTED_CODE,
+  INVOKE_CONTRACT_USER_MESSAGE,
+} from "@/app/lib/stellarOperations";
 
 // Sentry DSN from environment variables
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
@@ -44,7 +54,7 @@ export function initSentry() {
       
       // Sanitize wallet addresses and keys
       if (event.contexts) {
-        sanitizeContext(event.contexts);
+        sanitizeSentryContexts(event.contexts);
       }
       
       return event;
@@ -86,46 +96,15 @@ export function initSentry() {
   });
 }
 
-/**
- * Sanitize context to remove PII
- */
-function sanitizeContext(contexts: any) {
-  for (const key in contexts) {
-    if (typeof contexts[key] === "object" && contexts[key] !== null) {
-      const obj = contexts[key];
-      
-      // Redact wallet addresses
-      if (obj.wallet_address) {
-        obj.wallet_address = redactAddress(obj.wallet_address);
-      }
-      if (obj.public_key) {
-        obj.public_key = redactAddress(obj.public_key);
-      }
-      if (obj.address) {
-        obj.address = redactAddress(obj.address);
-      }
-      
-      // Redact secret keys
-      if (obj.secret_key) {
-        obj.secret_key = "[REDACTED]";
-      }
-      if (obj.private_key) {
-        obj.private_key = "[REDACTED]";
-      }
-      if (obj.mnemonic) {
-        obj.mnemonic = "[REDACTED]";
-      }
-    }
-  }
-}
-
-/**
- * Redact wallet address for logging (show first 6 and last 4 characters)
- */
-function redactAddress(address: string): string {
-  if (!address || typeof address !== "string") return "[REDACTED]";
-  if (address.length < 10) return "[REDACTED]";
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+export function captureSorobanNotSupportedWarning(context?: Record<string, unknown>) {
+  Sentry.captureMessage(INVOKE_CONTRACT_USER_MESSAGE, {
+    level: "warning",
+    tags: {
+      stellar_operation: "invoke_contract",
+      error_code: INVOKE_CONTRACT_NOT_SUPPORTED_CODE,
+    },
+    extra: context,
+  });
 }
 
 /**
@@ -141,15 +120,6 @@ export function setSentryUser(user: { id: string; email?: string } | null) {
     id: user.id,
     email: user.email ? redactEmail(user.email) : undefined,
   });
-}
-
-/**
- * Redact email for logging
- */
-function redactEmail(email: string): string {
-  const [local, domain] = email.split("@");
-  if (!domain) return "[REDACTED]";
-  return `${local[0]}***@${domain}`;
 }
 
 /**
@@ -238,15 +208,7 @@ export function addWalletBreadcrumb(
   category: string = "wallet",
   data?: any
 ) {
-  const breadcrumbData: any = { ...data };
-
-  // Redact sensitive data
-  if (data?.walletAddress) {
-    breadcrumbData.walletAddress = redactAddress(data.walletAddress);
-  }
-  if (data?.publicKey) {
-    breadcrumbData.publicKey = redactAddress(data.publicKey);
-  }
+  const breadcrumbData = sanitizeBreadcrumbPayload(data);
 
   Sentry.addBreadcrumb({
     message,

--- a/clips-frontend/app/lib/sentryRedaction.ts
+++ b/clips-frontend/app/lib/sentryRedaction.ts
@@ -1,0 +1,86 @@
+import type { Breadcrumb, Event } from "@sentry/types";
+
+export function redactAddress(address: string): string {
+  if (!address || typeof address !== "string") return "[REDACTED]";
+  if (address.length < 10) return "[REDACTED]";
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export function redactEmail(email: string): string {
+  const [local, domain] = email.split("@");
+  if (!domain) return "[REDACTED]";
+  return `${local[0]}***@${domain}`;
+}
+
+const SENSITIVE_KEY_PATTERNS =
+  /secret|private|mnemonic|seed|password|passphrase|recovery/i;
+
+export function redactSensitiveValue(key: string, value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (SENSITIVE_KEY_PATTERNS.test(key)) {
+    return "[REDACTED]";
+  }
+
+  if (
+    (key === "wallet_address" || key === "public_key" || key === "address") &&
+    typeof value === "string"
+  ) {
+    return redactAddress(value);
+  }
+
+  if (key === "email" && typeof value === "string") {
+    return redactEmail(value);
+  }
+
+  return value;
+}
+
+export function sanitizeContextObject(
+  obj: Record<string, unknown>
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = { ...obj };
+
+  for (const key of Object.keys(sanitized)) {
+    const value = sanitized[key];
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      sanitized[key] = sanitizeContextObject(value as Record<string, unknown>);
+    } else {
+      sanitized[key] = redactSensitiveValue(key, value);
+    }
+  }
+
+  return sanitized;
+}
+
+export function sanitizeSentryContexts(contexts: Event["contexts"]): void {
+  if (!contexts) return;
+
+  for (const key of Object.keys(contexts)) {
+    const ctx = contexts[key];
+    if (typeof ctx === "object" && ctx !== null) {
+      Object.assign(ctx, sanitizeContextObject(ctx as Record<string, unknown>));
+    }
+  }
+}
+
+export function sanitizeBreadcrumbData(
+  data: Breadcrumb["data"] | undefined
+): Breadcrumb["data"] | undefined {
+  if (!data || typeof data !== "object") return data;
+  return sanitizeContextObject(data as Record<string, unknown>);
+}
+
+export function sanitizeBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
+  return {
+    ...breadcrumb,
+    data: sanitizeBreadcrumbData(breadcrumb.data),
+  };
+}
+
+export function sanitizeBreadcrumbPayload(
+  data: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!data) return data;
+  return sanitizeContextObject(data);
+}

--- a/clips-frontend/app/lib/shamirRecovery.ts
+++ b/clips-frontend/app/lib/shamirRecovery.ts
@@ -1,0 +1,48 @@
+import secrets from "secrets.js-grempe";
+
+const BITS = 8;
+
+function toHex(secret: string): string {
+  return Array.from(secret, (char) => char.charCodeAt(0).toString(16).padStart(2, "0")).join(
+    ""
+  );
+}
+
+function fromHex(hex: string): string {
+  const chars: string[] = [];
+  for (let i = 0; i < hex.length; i += 2) {
+    chars.push(String.fromCharCode(parseInt(hex.slice(i, i + 2), 16)));
+  }
+  return chars.join("");
+}
+
+export type ShamirSplitOptions = {
+  shares: number;
+  threshold: number;
+};
+
+export function splitSecret(
+  secret: string,
+  options: ShamirSplitOptions
+): string[] {
+  const { shares, threshold } = options;
+  if (threshold < 2) {
+    throw new Error("Recovery threshold must be at least 2.");
+  }
+  if (shares < threshold) {
+    throw new Error("Number of guardians must be at least the recovery threshold.");
+  }
+
+  secrets.init(BITS);
+  return secrets.share(toHex(secret), shares, threshold);
+}
+
+export function combineShares(shareHexValues: string[]): string {
+  secrets.init(BITS);
+  return fromHex(secrets.combine(shareHexValues));
+}
+
+export function defaultRecoveryThreshold(guardianCount: number): number {
+  if (guardianCount < 2) return 2;
+  return Math.max(2, Math.ceil((guardianCount * 2) / 3));
+}

--- a/clips-frontend/app/lib/stellar.ts
+++ b/clips-frontend/app/lib/stellar.ts
@@ -7,7 +7,12 @@ import {
   getFriendbotUrl,
 } from "./networkConfig";
 import type { StellarOperation } from "./stellarOperations";
-import { validateOperations } from "./stellarOperations";
+import {
+  validateOperations,
+  invokeContractBuildError,
+  isInvokeContractBuildError,
+  type InvokeContractBuildError,
+} from "./stellarOperations";
 
 // Re-export so existing callers that import these from stellar.ts keep working.
 export { STELLAR_NETWORK };
@@ -165,7 +170,9 @@ export const submitTransaction = async (signedTx: StellarSdk.Transaction) => {
  * Convert a typed `StellarOperation` descriptor into a real Stellar SDK
  * `xdr.Operation` object.
  */
-function toSdkOperation(op: StellarOperation): StellarSdk.xdr.Operation {
+function toSdkOperation(
+  op: StellarOperation
+): StellarSdk.xdr.Operation | InvokeContractBuildError {
   switch (op.type) {
     case "payment": {
       const asset =
@@ -265,13 +272,7 @@ function toSdkOperation(op: StellarOperation): StellarSdk.xdr.Operation {
       });
 
     case "invoke_contract":
-      // Soroban contract invocations require the Soroban RPC path and a
-      // SorobanDataBuilder — this stub builds a placeholder operation.
-      // Replace with a full Soroban client call in production.
-      throw new Error(
-        "invoke_contract operations must be built via the Soroban RPC client. " +
-          "Use SorobanRpc.Server and assembleTransaction() before calling submitTransaction()."
-      );
+      return invokeContractBuildError();
 
     default: {
       const _exhaustive: never = op;
@@ -288,6 +289,12 @@ export interface BatchTransactionResult {
   /** Number of operations in the transaction */
   operationCount: number;
 }
+
+export type BuildBatchTransactionResult =
+  | ({ ok: true } & BatchTransactionResult)
+  | { ok: false; error: InvokeContractBuildError; operationIndex: number };
+
+export { isInvokeContractBuildError, type InvokeContractBuildError };
 
 /**
  * Build a multi-operation Stellar transaction and return the unsigned XDR.
@@ -314,7 +321,7 @@ export const buildBatchTransaction = async (
     memo?: string;
     timeoutSeconds?: number;
   } = {}
-): Promise<BatchTransactionResult> => {
+): Promise<BuildBatchTransactionResult> => {
   const { memo, timeoutSeconds = 30 } = options;
 
   // Validate before touching the network
@@ -349,8 +356,12 @@ export const buildBatchTransaction = async (
     networkPassphrase: NETWORK_PASSPHRASE,
   });
 
-  for (const op of operations) {
-    builder.addOperation(toSdkOperation(op));
+  for (let i = 0; i < operations.length; i++) {
+    const sdkOp = toSdkOperation(operations[i]);
+    if (isInvokeContractBuildError(sdkOp)) {
+      return { ok: false, error: sdkOp, operationIndex: i };
+    }
+    builder.addOperation(sdkOp);
   }
 
   if (memo) {
@@ -360,6 +371,7 @@ export const buildBatchTransaction = async (
   const transaction = builder.setTimeout(timeoutSeconds).build();
 
   return {
+    ok: true,
     xdr: transaction.toEnvelope().toXDR("base64"),
     feeStroops: totalFee,
     operationCount: operations.length,

--- a/clips-frontend/app/lib/stellarOperations.ts
+++ b/clips-frontend/app/lib/stellarOperations.ts
@@ -127,6 +127,35 @@ export interface InvokeContractOperation {
   source?: string;
 }
 
+/** Soroban implementation plan: SOROBAN_SMART_WALLET_SPIKE.md */
+export const INVOKE_CONTRACT_NOT_SUPPORTED_CODE = "INVOKE_CONTRACT_NOT_SUPPORTED" as const;
+
+export const INVOKE_CONTRACT_USER_MESSAGE =
+  "Smart contract interactions are not yet supported" as const;
+
+export type InvokeContractBuildError = {
+  code: typeof INVOKE_CONTRACT_NOT_SUPPORTED_CODE;
+  message: typeof INVOKE_CONTRACT_USER_MESSAGE;
+};
+
+export function invokeContractBuildError(): InvokeContractBuildError {
+  return {
+    code: INVOKE_CONTRACT_NOT_SUPPORTED_CODE,
+    message: INVOKE_CONTRACT_USER_MESSAGE,
+  };
+}
+
+export function isInvokeContractBuildError(
+  value: unknown
+): value is InvokeContractBuildError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    (value as InvokeContractBuildError).code === INVOKE_CONTRACT_NOT_SUPPORTED_CODE
+  );
+}
+
 /** Union of all supported operation descriptors */
 export type StellarOperation =
   | PaymentOperation

--- a/clips-frontend/app/lib/walletErrorTracking.ts
+++ b/clips-frontend/app/lib/walletErrorTracking.ts
@@ -1,3 +1,5 @@
+import { sanitizeBreadcrumbPayload } from "@/app/lib/sentryRedaction";
+
 /**
  * Wallet Error Tracking Utility
  * 
@@ -171,17 +173,8 @@ export function addWalletBreadcrumb(
   category: string = "wallet",
   data?: any
 ): void {
-  const breadcrumbData: any = { ...data };
+  const breadcrumbData = sanitizeBreadcrumbPayload(data);
 
-  // Redact sensitive data
-  if (data?.walletAddress) {
-    breadcrumbData.walletAddress = redactAddress(data.walletAddress);
-  }
-  if (data?.publicKey) {
-    breadcrumbData.publicKey = redactAddress(data.publicKey);
-  }
-
-  // Log to console
   console.log(`[Wallet Breadcrumb] ${category}: ${message}`, breadcrumbData);
 
   // Add to Sentry if available

--- a/clips-frontend/app/recovery/page.tsx
+++ b/clips-frontend/app/recovery/page.tsx
@@ -40,6 +40,8 @@ export default function RecoveryPage() {
   const [socialEmail, setSocialEmail] = useState("");
   const [sessionId, setSessionId] = useState("");
   const [guardians, setGuardians] = useState<{ email: string; approved: boolean }[]>([]);
+  const [recoveryThreshold, setRecoveryThreshold] = useState(2);
+  const [recoveryGuardianCount, setRecoveryGuardianCount] = useState(0);
   const [isRecoverable, setIsRecoverable] = useState(false);
   const [recoveryPassword, setRecoveryPassword] = useState("");
   const [simulating, setSimulating] = useState(false);
@@ -120,6 +122,8 @@ export default function RecoveryPage() {
       const res = await MockApi.initiateSocialRecovery(socialEmail);
       setSessionId(res.sessionId);
       setGuardians(res.guardians.map((g: string) => ({ email: g, approved: false })));
+      setRecoveryThreshold(res.threshold);
+      setRecoveryGuardianCount(res.guardianCount);
       setIsRecoverable(false);
     } catch (err: any) {
       setError(err.message || "Failed to find social recovery setup for this email.");
@@ -137,12 +141,21 @@ export default function RecoveryPage() {
       // Simulate Guardian 1 approving
       await new Promise((r) => setTimeout(r, 1000));
       let res = await MockApi.approveGuardian(sessionId, guardians[0].email);
-      setGuardians(res.guardians);
+      setGuardians(
+        res.guardians.map((g: { email: string; approved: boolean }) => ({
+          email: g.email,
+          approved: g.approved,
+        }))
+      );
 
-      // Simulate Guardian 2 approving (reaches threshold: 2/3)
       await new Promise((r) => setTimeout(r, 1200));
       res = await MockApi.approveGuardian(sessionId, guardians[1].email);
-      setGuardians(res.guardians);
+      setGuardians(
+        res.guardians.map((g: { email: string; approved: boolean }) => ({
+          email: g.email,
+          approved: g.approved,
+        }))
+      );
 
       // Verify recovery capability
       const status = await MockApi.checkSocialRecovery(sessionId);
@@ -389,7 +402,8 @@ export default function RecoveryPage() {
                         <Users className="w-3.5 h-3.5 text-brand" /> Guardian Approvals
                       </span>
                       <span className="text-[10px] font-mono text-brand font-bold bg-brand/10 border border-brand/20 px-2.5 py-0.5 rounded-full">
-                        {guardians.filter((g) => g.approved).length} / {guardians.length} Approved
+                        {guardians.filter((g) => g.approved).length} / {recoveryThreshold} required (
+                        {recoveryThreshold}-of-{recoveryGuardianCount})
                       </span>
                     </div>
 

--- a/clips-frontend/components/AuthProvider.tsx
+++ b/clips-frontend/components/AuthProvider.tsx
@@ -100,6 +100,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       syncedSessionEmailRef.current = null;
       if (authSourceRef.current === "session") {
         clearAuthState();
+        void signOut({ redirect: false });
       }
     }
 

--- a/clips-frontend/components/SocialRecoveryConfig.tsx
+++ b/clips-frontend/components/SocialRecoveryConfig.tsx
@@ -76,10 +76,11 @@ export const decryptWithPassword = async (encryptedBase64: string, password: str
 };
 
 export default function SocialRecoveryConfig() {
-  const { user } = useAuth();
+  const { user, setUser } = useAuth();
   const { isConnected, walletType, stellarMnemonic, stellarSecret } = useWallet();
 
   const [guardians, setGuardians] = useState<string[]>(["", "", ""]);
+  const [threshold, setThreshold] = useState(2);
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -87,16 +88,11 @@ export default function SocialRecoveryConfig() {
 
   const isStellar = isConnected && walletType === "stellar";
 
-  // Pre-populate guardians from logged-in user if available
   useEffect(() => {
-    if (user && (user as any).guardians) {
-      const g = (user as any).guardians;
-      if (Array.isArray(g) && g.length > 0) {
-        // Pads array to at least 3 elements
-        const padded = [...g];
-        while (padded.length < 3) padded.push("");
-        setGuardians(padded);
-      }
+    if (user?.socialRecoveryGuardianCount && user.socialRecoveryGuardianCount > 0) {
+      const count = Math.max(user.socialRecoveryGuardianCount, 3);
+      setGuardians(Array.from({ length: count }, () => ""));
+      setThreshold(user.socialRecoveryThreshold ?? 2);
     }
   }, [user]);
 
@@ -129,6 +125,13 @@ export default function SocialRecoveryConfig() {
       return;
     }
 
+    if (threshold < 2 || threshold > activeGuardians.length) {
+      setError(
+        `Recovery threshold must be between 2 and ${activeGuardians.length} (you have ${activeGuardians.length} guardians).`
+      );
+      return;
+    }
+
     // Validate email format
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     for (const g of activeGuardians) {
@@ -150,13 +153,17 @@ export default function SocialRecoveryConfig() {
 
       // 2. Save recovery configuration to backend
       if (user?.email) {
-        await MockApi.saveSocialRecoveryConfig(user.email, activeGuardians, cipherText);
-        
-        // Update local mock user reference
-        if ((user as any).guardians) {
-          (user as any).guardians = activeGuardians;
-          (user as any).encryptedWalletBackup = cipherText;
-        }
+        const saved = await MockApi.saveSocialRecoveryConfig(
+          user.email,
+          activeGuardians,
+          cipherText,
+          threshold
+        );
+        setUser({
+          ...user,
+          socialRecoveryThreshold: saved.threshold,
+          socialRecoveryGuardianCount: saved.guardianCount,
+        });
 
         setSuccess(true);
         setPassword("");
@@ -184,9 +191,9 @@ export default function SocialRecoveryConfig() {
         <div>
           <h3 className="text-[16px] font-extrabold text-white">Social Wallet Recovery</h3>
           <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
-            Protect your assets by assigning trusted guardians (friends, family, or other email accounts).
-            If you ever lose access to your password, 2 out of 3 guardians can approve your recovery request
-            to restore your Stellar wallet keys.
+            Assign trusted guardians by email. Your wallet backup is split with Shamir secret sharing;
+            recovery requires approval from at least your chosen threshold of guardians, plus your
+            recovery password. Guardian invitations are sent by email (mocked in this environment).
           </p>
         </div>
       </div>
@@ -216,8 +223,38 @@ export default function SocialRecoveryConfig() {
               </div>
             ))}
             <span className="text-[10px] text-muted-foreground mt-1.5 block">
-              At least 2 guardians must be active to initiate a recovery request.
+              Configure at least 2 guardians. Each receives an email invitation with their secret share.
             </span>
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-[11px] font-bold text-muted-foreground tracking-wider uppercase">
+              Recovery threshold (t-of-n)
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="number"
+                min={2}
+                max={Math.max(2, guardians.filter((g) => g.length > 0).length || 3)}
+                value={threshold}
+                onChange={(e) => {
+                  const next = Number(e.target.value);
+                  const activeCount = guardians.filter((g) => g.length > 0).length || 3;
+                  setThreshold(
+                    Math.min(Math.max(2, next), Math.max(2, activeCount))
+                  );
+                }}
+                className="w-20 bg-input border border-white/5 text-white focus:border-brand/40 rounded-xl px-3 py-2 text-xs focus:outline-none"
+              />
+              <span className="text-[10px] text-muted-foreground">
+                Require{" "}
+                <strong className="text-white">{threshold}</strong> of{" "}
+                <strong className="text-white">
+                  {guardians.filter((g) => g.length > 0).length || "n"}
+                </strong>{" "}
+                guardians to approve recovery before your key can be restored.
+              </span>
+            </div>
           </div>
 
           <div className="h-px bg-white/5 my-4" />

--- a/clips-frontend/package-lock.json
+++ b/clips-frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "clipsproject",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/nextjs": "^10.55.0",
+        "@sentry/types": "^10.55.0",
         "@stellar/stellar-sdk": "^15.1.0",
         "bip39": "^3.1.0",
         "canvas-confetti": "^1.9.4",
@@ -17,6 +19,7 @@
         "qrcode": "^1.5.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "secrets.js-grempe": "^2.0.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -98,7 +101,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -113,7 +115,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -123,7 +124,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -154,7 +154,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -171,7 +170,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -188,7 +186,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -198,7 +195,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -212,7 +208,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -240,7 +235,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -250,7 +244,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -260,7 +253,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -270,7 +262,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -284,7 +275,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -548,7 +538,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -563,7 +552,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -582,7 +570,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -2928,7 +2915,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2939,7 +2925,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2950,24 +2935,32 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3397,6 +3390,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -4466,11 +4554,65 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
+      "integrity": "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
       "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -4493,7 +4635,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4502,12 +4643,877 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.55.0.tgz",
+      "integrity": "sha512-zUvyBr13EK0evKsSTzwSimRzZ3P9kugS32dLCj3ea5gNN+/DFtU/GsMTdcIQDhusEDraIlH17AGgqJH5gUAv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.55.0.tgz",
+      "integrity": "sha512-32X9WW1xs5DjCRlp89QJ/PLw4kbTIX6MsBDXN2RBN1nWBjm/2WcwXqO/v/WoIS4W2kTWXcZnQwalLSI22Fp33A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.55.0.tgz",
+      "integrity": "sha512-OkQpANGwYU5UKfwLk6Y+NpESRC8nrLBjawRDLwF6cJ8HpNScOuNNJDEJEGwXHVkJPH0pcIixsH8y0Qfcltq6Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.55.0",
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.55.0.tgz",
+      "integrity": "sha512-lu/y7k9cK7FZ/qJpL0fBX4WqK6IFa/+bTPhedEaC5UpzjUNP7BfXt0H+R7q9CHWmp20Ffh/wGfO3j7O+Tv2MAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.55.0",
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
+      "integrity": "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.55.0.tgz",
+      "integrity": "sha512-5n1kxmW1m4j16ZDV9kt+Zo5uafFnKTy7s5YyEcGnC45KnOiO1Gy+QFd3woXns1K5GNxpjF7oOOc6tXgZLuXnQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.55.0",
+        "@sentry-internal/feedback": "10.55.0",
+        "@sentry-internal/replay": "10.55.0",
+        "@sentry-internal/replay-canvas": "10.55.0",
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.3.0.tgz",
+      "integrity": "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "5.3.0",
+        "@sentry/cli": "^2.58.5",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.55.0.tgz",
+      "integrity": "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/nextjs": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.55.0.tgz",
+      "integrity": "sha512-ODiv6hy7+gmINFvbWAVaCqtxT2ceFW7AW65amy34z3fCgld9+LHTP2++p4g2LmQb/mYQPIbJrVEfJoqGASK4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@rollup/plugin-commonjs": "28.0.1",
+        "@sentry-internal/browser-utils": "10.55.0",
+        "@sentry/bundler-plugin-core": "^5.3.0",
+        "@sentry/core": "10.55.0",
+        "@sentry/node": "10.55.0",
+        "@sentry/opentelemetry": "10.55.0",
+        "@sentry/react": "10.55.0",
+        "@sentry/vercel-edge": "10.55.0",
+        "@sentry/webpack-plugin": "^5.3.0",
+        "rollup": "^4.60.3",
+        "stacktrace-parser": "^0.1.11"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.55.0.tgz",
+      "integrity": "sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry/core": "10.55.0",
+        "@sentry/node-core": "10.55.0",
+        "@sentry/opentelemetry": "10.55.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.55.0.tgz",
+      "integrity": "sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.55.0",
+        "@sentry/opentelemetry": "10.55.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.55.0.tgz",
+      "integrity": "sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.55.0.tgz",
+      "integrity": "sha512-cf6wI0W1FdrL/7d5FTHXUdTN5k5uRZ9AQu5QZxUujnxWN+DBxUWtow1HDD1zTEonQsCFyYuhXVu3w+qmBBW11A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.55.0",
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.55.0.tgz",
+      "integrity": "sha512-5oXc4yJXWsqcfpCMrEXGMzuKjJFf4kaeHMukwfWSXuoM6pUot545Dt5oeLhrGd2IVRYcHZVt057sd9JscRx9Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vercel-edge": {
+      "version": "10.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.55.0.tgz",
+      "integrity": "sha512-IB8MBTdCHnuUtxHWh39Ecr9/TvMqSYW9BOO7ExnByDjHhfXOzQnEs6VJvEEIwSyUEl1yIz1Y3WdOlY9I6lqeMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/resources": "^2.6.1",
+        "@sentry/core": "10.55.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/webpack-plugin": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-5.3.0.tgz",
+      "integrity": "sha512-i3OQUrS0FZlXLgq57RIKDp+vHHzuvYKPCKewAPXULWKMsBXFGhP6veGRQ+6To/pmZkkXjEX5ofVNDy9C3jEPKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "webpack": ">=5.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -5502,7 +6508,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -5594,7 +6599,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -5615,7 +6619,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -6511,6 +7514,167 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
     "node_modules/@webcontainer/env": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
@@ -6518,17 +7682,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -6567,6 +7766,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -7146,7 +8387,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7214,7 +8454,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -7434,6 +8673,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -7454,7 +8703,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -7653,6 +8901,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7664,7 +8918,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -7798,7 +9051,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8038,6 +9290,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8063,7 +9327,6 @@
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -8097,14 +9360,13 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
-      "dev": true,
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
+      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -8293,7 +9555,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -8400,7 +9661,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8831,7 +10091,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -8844,7 +10103,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8854,7 +10112,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -8873,6 +10130,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
@@ -8963,7 +10230,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9009,6 +10275,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -9069,7 +10352,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -9281,7 +10563,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -9435,6 +10716,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
@@ -9535,7 +10823,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -9555,7 +10842,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9800,6 +11086,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/import-local": {
@@ -10212,6 +11513,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -10430,7 +11740,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -11568,7 +12877,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11628,7 +12936,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11676,7 +12983,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -12305,11 +13611,24 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -12484,7 +13803,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -12514,7 +13832,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -12584,7 +13901,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -12692,7 +14008,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -12703,6 +14018,12 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.3.4.tgz",
       "integrity": "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
     "node_modules/mri": {
@@ -12729,7 +14050,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -12772,6 +14092,13 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/next": {
       "version": "16.2.2",
@@ -12905,6 +14232,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12916,7 +14285,6 @@
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -13315,7 +14683,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -13331,7 +14698,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -13810,6 +15176,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -14314,6 +15689,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -14482,6 +15880,50 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -14627,11 +16069,73 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/secrets.js-grempe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/secrets.js-grempe/-/secrets.js-grempe-2.0.0.tgz",
+      "integrity": "sha512-4xkOIaDAg998dTFXZUJTOoVbdLHfB818SMeLJ69ABccgGEKokxsoRFupAFfAImloUSKv4QUGNMgKVbKMf6z0Ug==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14960,7 +16464,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15047,6 +16550,27 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stacktrace-parser/node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -15515,10 +17039,9 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
-      "dev": true,
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15539,6 +17062,135 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {
@@ -16030,7 +17682,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -16111,7 +17762,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16517,6 +18167,20 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -16527,12 +18191,103 @@
         "node": ">=12"
       }
     },
+    "node_modules/webpack": {
+      "version": "5.107.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.22.0",
+        "es-module-lexer": "^2.1.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.5.0",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.5.0"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
@@ -16576,7 +18331,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -16884,7 +18638,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -16971,7 +18724,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/clips-frontend/package.json
+++ b/clips-frontend/package.json
@@ -15,6 +15,8 @@
     "changeset": "changeset"
   },
   "dependencies": {
+    "@sentry/nextjs": "^10.55.0",
+    "@sentry/types": "^10.55.0",
     "@stellar/stellar-sdk": "^15.1.0",
     "bip39": "^3.1.0",
     "canvas-confetti": "^1.9.4",
@@ -24,6 +26,7 @@
     "qrcode": "^1.5.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "secrets.js-grempe": "^2.0.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/clips-frontend/sentry.client.config.ts
+++ b/clips-frontend/sentry.client.config.ts
@@ -1,53 +1,56 @@
 /**
  * Sentry Client Configuration
- * 
+ *
  * This file configures Sentry for client-side error tracking.
  * It's automatically loaded by Next.js when the app runs in the browser.
+ *
+ * Breadcrumb audit (addBreadcrumb call sites):
+ * - app/lib/sentry.ts addWalletBreadcrumb — wallet context; sanitized via sanitizeBreadcrumbPayload
+ * - app/lib/walletErrorTracking.ts addWalletBreadcrumb — wallet ops; sanitized before addBreadcrumb
+ * Breadcrumbs bypass beforeSend; beforeBreadcrumb below mirrors beforeSend PII redaction.
  */
 
 import * as Sentry from "@sentry/nextjs";
+import {
+  sanitizeBreadcrumb,
+  sanitizeSentryContexts,
+} from "@/app/lib/sentryRedaction";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || process.env.NODE_ENV,
   release: process.env.NEXT_PUBLIC_SENTRY_RELEASE || process.env.VERCEL_GIT_COMMIT_SHA || "development",
-  
-  // Performance monitoring
+
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  
-  // Session replay
+
   replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
   replaysOnErrorSampleRate: 1.0,
-  
-  // Filter out PII from events
-  beforeSend(event, hint) {
-    // Filter out sensitive data
+
+  beforeSend(event) {
     if (event.request) {
       delete event.request.cookies;
       delete event.request.headers;
     }
-    
-    // Sanitize wallet addresses and keys
+
     if (event.contexts) {
-      sanitizeContext(event.contexts);
+      sanitizeSentryContexts(event.contexts);
     }
-    
+
     return event;
   },
-  
-  // Ignore specific errors
+
+  beforeBreadcrumb(breadcrumb) {
+    return sanitizeBreadcrumb(breadcrumb);
+  },
+
   ignoreErrors: [
-    // Ignore network errors that are expected
     "Network request failed",
     "Failed to fetch",
-    // Ignore user cancellation errors
     "User rejected the request",
     "User cancelled the request",
-    // Ignore browser extension errors
     "Extension context invalidated",
   ],
-  
-  // Integrations
+
   integrations: [
     new Sentry.BrowserTracing({
       tracingOrigins: ["localhost", "clips-frontend.vercel.app", /^\//],
@@ -58,55 +61,11 @@ Sentry.init({
       blockAllMedia: true,
     }),
   ],
-  
-  // Before send transaction
+
   beforeSendTransaction(transaction) {
-    // Filter out health check transactions
     if (transaction.name === "/health" || transaction.name === "/api/health") {
       return null;
     }
     return transaction;
   },
 });
-
-/**
- * Sanitize context to remove PII
- */
-function sanitizeContext(contexts: any) {
-  for (const key in contexts) {
-    if (typeof contexts[key] === "object" && contexts[key] !== null) {
-      const obj = contexts[key];
-      
-      // Redact wallet addresses
-      if (obj.wallet_address) {
-        obj.wallet_address = redactAddress(obj.wallet_address);
-      }
-      if (obj.public_key) {
-        obj.public_key = redactAddress(obj.public_key);
-      }
-      if (obj.address) {
-        obj.address = redactAddress(obj.address);
-      }
-      
-      // Redact secret keys
-      if (obj.secret_key) {
-        obj.secret_key = "[REDACTED]";
-      }
-      if (obj.private_key) {
-        obj.private_key = "[REDACTED]";
-      }
-      if (obj.mnemonic) {
-        obj.mnemonic = "[REDACTED]";
-      }
-    }
-  }
-}
-
-/**
- * Redact wallet address for logging (show first 6 and last 4 characters)
- */
-function redactAddress(address: string): string {
-  if (!address || typeof address !== "string") return "[REDACTED]";
-  if (address.length < 10) return "[REDACTED]";
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}


### PR DESCRIPTION
## Summary

This PR addresses four related improvements to wallet auth, Stellar operations, error monitoring, and social recovery.

### 1. Soroban `invoke_contract` — graceful handling

- `invoke_contract` returns a typed `InvokeContractBuildError` instead of throwing at runtime
- `buildBatchTransaction` returns `{ ok: false, error, operationIndex }` when a batch includes contract invocations
- `useStellarTransaction` surfaces: **Smart contract interactions are not yet supported**
- Sentry records a **warning** (not an error) via `captureSorobanNotSupportedWarning()`
- Implementation plan reference: `SOROBAN_SMART_WALLET_SPIKE.md`

### 2. `AuthProvider` test coverage

Tests added/updated in `__tests__/components/AuthProvider.test.tsx`:

- Unauthenticated users on protected routes are redirected to `/login`
- Authenticated users on protected routes are not redirected
- While `status === "loading"`, children render without redirect
- Session expiry clears auth state and calls `signOut({ redirect: false })`

### 3. Sentry breadcrumb PII redaction

- Shared redaction helpers in `app/lib/sentryRedaction.ts`
- `beforeBreadcrumb` added to `sentry.client.config.ts` (mirrors `beforeSend` patterns)
- Audited and sanitized `Sentry.addBreadcrumb` usage in `sentry.ts` and `walletErrorTracking.ts`
- Test: `__tests__/lib/sentryBreadcrumbs.test.ts` — wallet errors must not leak key material in breadcrumbs

### 4. Social recovery — Shamir secret sharing

- Encrypted wallet backup split with **t-of-n** Shamir sharing (`secrets.js-grempe`)
- Guardian invitations sent via mock email (`sendGuardianInvitation`); production needs a real email backend
- Recovery requires **≥ t** guardian approvals before the encrypted backup is returned
- UI shows configurable recovery threshold in settings and **t-of-n** progress on `/recovery`
- Security model documented in `SECURITY.md`

## Dependencies

| Package | Purpose |
| --- | --- |
| `@sentry/nextjs` | Sentry client integration (warning capture, breadcrumbs) |
| `secrets.js-grempe` | Shamir t-of-n secret sharing for guardian recovery |

## Test plan

- [ ] `cd clips-frontend && npm test -- __tests__/components/AuthProvider.test.tsx __tests__/lib/stellarInvokeContract.test.ts __tests__/lib/sentryBreadcrumbs.test.ts __tests__/lib/shamirRecovery.test.ts`
- [ ] Queue an `invoke_contract` operation and confirm the friendly error (no uncaught exception)
- [ ] Configure social recovery: ≥2 guardians, set threshold, save — confirm success message
- [ ] `/recovery` → Social tab: initiate recovery, simulate guardian approvals, complete with recovery password
- [ ] Trigger a wallet error with Sentry enabled and verify breadcrumbs do not contain `secretKey`, `mnemonic`, or `private_key` values

## Files changed (high level)

| Area | Key files |
| --- | --- |
| Stellar / Soroban | `app/lib/stellarOperations.ts`, `app/lib/stellar.ts`, `app/hooks/useStellarTransaction.ts` |
| Auth | `components/AuthProvider.tsx`, `__tests__/components/AuthProvider.test.tsx` |
| Sentry | `sentry.client.config.ts`, `app/lib/sentryRedaction.ts`, `app/lib/sentry.ts`, `app/lib/walletErrorTracking.ts` |
| Social recovery | `app/lib/shamirRecovery.ts`, `app/lib/mockApi.ts`, `components/SocialRecoveryConfig.tsx`, `app/recovery/page.tsx`, `SECURITY.md` |



closes #433 
closes #434 
closes #432 
closes #431 

