### PR TITLE
closes #436 closes #442: multi-wallet CRUD tests and real cloud storage upload

### DIFF
--- a/clips-frontend/.env.example
+++ b/clips-frontend/.env.example
@@ -1,0 +1,25 @@
+# Cloud Storage — Issue #442
+# Copy this file to .env.local and fill in your values.
+# All CLOUD_STORAGE_* and AWS_* vars are required for the upload API.
+
+# Provider: "s3" (default) | "r2" | "gcs"
+CLOUD_STORAGE_PROVIDER=s3
+
+# Bucket name (create this in your cloud console first)
+CLOUD_STORAGE_BUCKET=clips-uploads
+
+# Region (use "auto" for Cloudflare R2)
+CLOUD_STORAGE_REGION=us-east-1
+
+# Custom endpoint — required for Cloudflare R2 and GCS S3 interop.
+# Leave blank for standard AWS S3.
+# R2 example: https://<account-id>.r2.cloudflarestorage.com
+# GCS example: https://storage.googleapis.com
+CLOUD_STORAGE_ENDPOINT=
+
+# Object key prefix (default: "uploads/")
+CLOUD_STORAGE_KEY_PREFIX=uploads/
+
+# AWS / R2 / GCS S3-interop credentials
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key

--- a/clips-frontend/__tests__/components/MultiWalletProvider.test.tsx
+++ b/clips-frontend/__tests__/components/MultiWalletProvider.test.tsx
@@ -1,0 +1,344 @@
+/**
+ * Tests for MultiWalletProvider — Issue #436
+ *
+ * Covers:
+ * - Initial state: empty wallets for unauthenticated user
+ * - addWallet: wallet appears in context, analytics fired
+ * - removeWallet: blocked for primary, allowed for secondary
+ * - switchWallet: context reflects new active wallet
+ * - setPrimaryWallet: new primary reflected in context
+ * - refreshWallets: re-reads storage and updates state
+ * - migrateToMultiWallet helper: runs migration once
+ * - Error state: set and cleared correctly
+ *
+ * localStorage is mocked via jest.spyOn(Storage.prototype, ...).
+ * AuthProvider is mocked to control the authenticated user.
+ * analytics and walletErrorTracking are mocked to avoid side-effects.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  MultiWalletProvider,
+  useMultiWallet,
+  migrateToMultiWallet,
+} from "@/components/MultiWalletProvider";
+import { MultiWalletStorage } from "@/app/lib/multiWalletStorage";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+const mockUser = { id: "user_test_123", email: "test@clips.app" };
+
+jest.mock("@/components/AuthProvider", () => ({
+  useAuth: jest.fn(() => ({ user: mockUser })),
+}));
+
+jest.mock("@/lib/analytics", () => ({
+  __esModule: true,
+  default: { trackEvent: jest.fn() },
+}));
+
+jest.mock("@/app/lib/walletErrorTracking", () => ({
+  captureWalletError: jest.fn(),
+  logWalletOperation: jest.fn(),
+  addWalletBreadcrumb: jest.fn(),
+  setWalletUserContext: jest.fn(),
+}));
+
+// ─── localStorage mock ────────────────────────────────────────────────────────
+
+let lsStore: Record<string, string> = {};
+
+beforeEach(() => {
+  lsStore = {};
+  jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => lsStore[key] ?? null);
+  jest.spyOn(Storage.prototype, "setItem").mockImplementation((key, val) => { lsStore[key] = val; });
+  jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => { delete lsStore[key]; });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+});
+
+// ─── Wrapper ──────────────────────────────────────────────────────────────────
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MultiWalletProvider>{children}</MultiWalletProvider>
+);
+
+function baseWallet(overrides = {}) {
+  return {
+    publicKey: "GABCDEFGHIJKLMNOP",
+    walletType: "embedded" as const,
+    isPrimary: false,
+    isActive: false,
+    label: "Test Wallet",
+    ...overrides,
+  };
+}
+
+// ─── Initial state ────────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — initial state", () => {
+  it("starts with empty wallets and null activeWallet", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.wallets).toHaveLength(0);
+      expect(result.current.activeWallet).toBeNull();
+      expect(result.current.primaryWallet).toBeNull();
+    });
+  });
+
+  it("starts with isOperating=false and error=null", () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+    expect(result.current.isOperating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears state when user is null", async () => {
+    const { useAuth } = require("@/components/AuthProvider");
+    useAuth.mockReturnValue({ user: null });
+
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.wallets).toHaveLength(0);
+    });
+
+    useAuth.mockReturnValue({ user: mockUser });
+  });
+});
+
+// ─── addWallet ────────────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — addWallet", () => {
+  it("adds a wallet and updates wallets state", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let added: any;
+    await act(async () => {
+      added = await result.current.addWallet(baseWallet({ publicKey: "G_NEW_KEY" }));
+    });
+
+    expect(result.current.wallets).toHaveLength(1);
+    expect(result.current.wallets[0].publicKey).toBe("G_NEW_KEY");
+  });
+
+  it("first added wallet becomes active and primary", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+    await act(async () => {
+      await result.current.addWallet(baseWallet({ publicKey: "G_FIRST" }));
+    });
+    expect(result.current.activeWallet?.publicKey).toBe("G_FIRST");
+    expect(result.current.primaryWallet?.publicKey).toBe("G_FIRST");
+  });
+
+  it("fires analytics.trackEvent('wallet_added') on success", async () => {
+    const analytics = require("@/lib/analytics").default;
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+    await act(async () => {
+      await result.current.addWallet(baseWallet());
+    });
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      "wallet_added",
+      expect.objectContaining({ wallet_type: "embedded" })
+    );
+  });
+
+  it("sets error state when storage throws", async () => {
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+    await act(async () => {
+      try {
+        await result.current.addWallet(baseWallet());
+      } catch {}
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+  });
+});
+
+// ─── removeWallet ─────────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — removeWallet", () => {
+  it("removes a non-primary wallet successfully", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let first: any, second: any;
+    await act(async () => {
+      first = await result.current.addWallet(baseWallet({ publicKey: "K1" }));
+      second = await result.current.addWallet(baseWallet({ publicKey: "K2", isActive: true }));
+    });
+
+    act(() => {
+      result.current.removeWallet(second.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.wallets).toHaveLength(1);
+      expect(result.current.wallets[0].publicKey).toBe("K1");
+    });
+  });
+
+  it("sets error and does NOT remove the primary wallet", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let primary: any;
+    await act(async () => {
+      primary = await result.current.addWallet(baseWallet({ publicKey: "PRIMARY" }));
+    });
+
+    act(() => {
+      result.current.removeWallet(primary.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toMatch(/Cannot remove primary wallet/i);
+      expect(result.current.wallets).toHaveLength(1);
+    });
+  });
+});
+
+// ─── switchWallet ─────────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — switchWallet", () => {
+  it("makes the target wallet active", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let first: any, second: any;
+    await act(async () => {
+      first = await result.current.addWallet(baseWallet({ publicKey: "K1" }));
+      second = await result.current.addWallet(baseWallet({ publicKey: "K2" }));
+    });
+
+    act(() => {
+      result.current.switchWallet(second.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeWallet?.publicKey).toBe("K2");
+    });
+  });
+
+  it("fires analytics.trackEvent('wallet_switched') on success", async () => {
+    const analytics = require("@/lib/analytics").default;
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let first: any, second: any;
+    await act(async () => {
+      first = await result.current.addWallet(baseWallet({ publicKey: "K1" }));
+      second = await result.current.addWallet(baseWallet({ publicKey: "K2" }));
+    });
+
+    analytics.trackEvent.mockClear();
+    act(() => result.current.switchWallet(second.id));
+
+    await waitFor(() => {
+      expect(analytics.trackEvent).toHaveBeenCalledWith(
+        "wallet_switched",
+        expect.any(Object)
+      );
+    });
+  });
+});
+
+// ─── setPrimaryWallet ─────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — setPrimaryWallet", () => {
+  it("designates the target wallet as primary", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let first: any, second: any;
+    await act(async () => {
+      first = await result.current.addWallet(baseWallet({ publicKey: "K1" }));
+      second = await result.current.addWallet(baseWallet({ publicKey: "K2" }));
+    });
+
+    act(() => {
+      result.current.setPrimaryWallet(second.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.primaryWallet?.publicKey).toBe("K2");
+    });
+  });
+
+  it("only one wallet is primary after setPrimaryWallet", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let first: any, second: any;
+    await act(async () => {
+      first = await result.current.addWallet(baseWallet({ publicKey: "K1" }));
+      second = await result.current.addWallet(baseWallet({ publicKey: "K2" }));
+    });
+
+    act(() => result.current.setPrimaryWallet(second.id));
+    await waitFor(() => {
+      expect(result.current.wallets.filter((w) => w.isPrimary)).toHaveLength(1);
+    });
+  });
+});
+
+// ─── clearError ───────────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — clearError", () => {
+  it("clears the error state", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    let primary: any;
+    await act(async () => {
+      primary = await result.current.addWallet(baseWallet());
+    });
+
+    act(() => result.current.removeWallet(primary.id)); // sets error
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => result.current.clearError());
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+});
+
+// ─── refreshWallets ───────────────────────────────────────────────────────────
+
+describe("MultiWalletProvider — refreshWallets", () => {
+  it("re-reads storage after an external modification", async () => {
+    const { result } = renderHook(() => useMultiWallet(), { wrapper });
+
+    // Add wallet directly via storage (simulating external write)
+    MultiWalletStorage.addWallet(mockUser.id, baseWallet({ publicKey: "EXTERNAL" }));
+
+    act(() => result.current.refreshWallets());
+
+    await waitFor(() => {
+      expect(result.current.wallets.some((w) => w.publicKey === "EXTERNAL")).toBe(true);
+    });
+  });
+});
+
+// ─── migrateToMultiWallet ─────────────────────────────────────────────────────
+
+describe("migrateToMultiWallet helper", () => {
+  it("creates a primary wallet from single-wallet data", () => {
+    migrateToMultiWallet(mockUser.id, {
+      publicKey: "G_MIGRATE",
+      walletType: "embedded",
+      network: "testnet",
+    });
+    const all = MultiWalletStorage.getAll(mockUser.id);
+    expect(all).toHaveLength(1);
+    expect(all[0].publicKey).toBe("G_MIGRATE");
+    expect(all[0].isPrimary).toBe(true);
+  });
+
+  it("is idempotent — second call is a no-op", () => {
+    migrateToMultiWallet(mockUser.id, { publicKey: "G_M1", walletType: "embedded" });
+    migrateToMultiWallet(mockUser.id, { publicKey: "G_M2", walletType: "metamask" });
+    expect(MultiWalletStorage.getAll(mockUser.id)).toHaveLength(1);
+    expect(MultiWalletStorage.getAll(mockUser.id)[0].publicKey).toBe("G_M1");
+  });
+});

--- a/clips-frontend/__tests__/lib/multiWalletStorage.test.ts
+++ b/clips-frontend/__tests__/lib/multiWalletStorage.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for multiWalletStorage.ts — Issue #436
+ *
+ * Covers:
+ * - addWallet: first wallet, subsequent wallets, primary/active flags
+ * - removeWallet: removes correctly, re-assigns active/primary on removal
+ * - setActiveWallet (switch primary): deactivates previous, activates new
+ * - getAll / getWalletData: list wallets, active/primary resolution
+ * - migrateFromSingleWallet: migration path from single-wallet storage
+ * - Error paths: storage unavailable, storage full, wallet not found
+ * - Concurrent add/remove consistency
+ *
+ * localStorage is mocked via jest.spyOn so no real storage is touched.
+ */
+
+import {
+  MultiWalletStorage,
+  MultiWalletStorageError,
+  MultiWalletRecord,
+  WalletProviderType,
+} from "@/app/lib/multiWalletStorage";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const USER_A = "user_alice";
+const USER_B = "user_bob";
+const PREFIX = "clipcash_multi_wallets_";
+
+function walletKey(userId: string) {
+  return `${PREFIX}${userId}`;
+}
+
+function makeWalletInput(
+  overrides: Partial<Omit<MultiWalletRecord, "id" | "userId" | "createdAt" | "lastUsedAt">> = {}
+): Omit<MultiWalletRecord, "id" | "userId" | "createdAt" | "lastUsedAt"> {
+  return {
+    publicKey: "GABCDE1234567890",
+    walletType: "embedded" as WalletProviderType,
+    isPrimary: false,
+    isActive: false,
+    label: "Test Wallet",
+    ...overrides,
+  };
+}
+
+// In-memory localStorage stand-in
+function makeLocalStorageMock() {
+  let store: Record<string, string> = {};
+  return {
+    store,
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: jest.fn((key: string) => { delete store[key]; }),
+    clear: jest.fn(() => { store = {}; }),
+    reset() { store = {}; this.getItem.mockClear(); this.setItem.mockClear(); this.removeItem.mockClear(); },
+  };
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let lsMock: ReturnType<typeof makeLocalStorageMock>;
+
+beforeEach(() => {
+  lsMock = makeLocalStorageMock();
+  jest.spyOn(Storage.prototype, "getItem").mockImplementation(lsMock.getItem);
+  jest.spyOn(Storage.prototype, "setItem").mockImplementation(lsMock.setItem);
+  jest.spyOn(Storage.prototype, "removeItem").mockImplementation(lsMock.removeItem);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── getAll ───────────────────────────────────────────────────────────────────
+
+describe("MultiWalletStorage.getAll", () => {
+  it("returns empty array when no wallets are stored", () => {
+    expect(MultiWalletStorage.getAll(USER_A)).toEqual([]);
+  });
+
+  it("returns wallets for the correct user only", () => {
+    const w = MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    expect(MultiWalletStorage.getAll(USER_A)).toHaveLength(1);
+    expect(MultiWalletStorage.getAll(USER_B)).toHaveLength(0);
+  });
+
+  it("returns all wallets in insertion order", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2" }));
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all.map((w) => w.publicKey)).toEqual(["KEY_1", "KEY_2"]);
+  });
+
+  it("returns empty array when stored JSON is malformed", () => {
+    lsMock.store[walletKey(USER_A)] = "{{not json}}";
+    expect(MultiWalletStorage.getAll(USER_A)).toEqual([]);
+  });
+});
+
+// ─── addWallet ────────────────────────────────────────────────────────────────
+
+describe("MultiWalletStorage.addWallet", () => {
+  it("first wallet is automatically primary and active", () => {
+    const w = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ isPrimary: false, isActive: false }));
+    expect(w.isPrimary).toBe(true);
+    expect(w.isActive).toBe(true);
+  });
+
+  it("returns wallet with generated id, userId, createdAt, lastUsedAt", () => {
+    const w = MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    expect(w.id).toMatch(/^wallet_/);
+    expect(w.userId).toBe(USER_A);
+    expect(w.createdAt).toBeTruthy();
+    expect(w.lastUsedAt).toBeTruthy();
+  });
+
+  it("persists wallet to localStorage under correct key", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "G_TEST" }));
+    expect(lsMock.setItem).toHaveBeenCalledWith(
+      walletKey(USER_A),
+      expect.stringContaining("G_TEST")
+    );
+  });
+
+  it("adding a second wallet deactivates the first when isActive=true", () => {
+    const first = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2", isActive: true }));
+    const all = MultiWalletStorage.getAll(USER_A);
+    const firstStored = all.find((w) => w.id === first.id)!;
+    const second = all.find((w) => w.publicKey === "KEY_2")!;
+    expect(firstStored.isActive).toBe(false);
+    expect(second.isActive).toBe(true);
+  });
+
+  it("adding a wallet with isPrimary=true unmarks previous primary", () => {
+    const first = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2", isPrimary: true, isActive: false }));
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all.find((w) => w.id === first.id)!.isPrimary).toBe(false);
+    expect(all.find((w) => w.publicKey === "KEY_2")!.isPrimary).toBe(true);
+  });
+
+  it("throws STORAGE_UNAVAILABLE when localStorage is not accessible", () => {
+    jest.restoreAllMocks();
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new DOMException("SecurityError"); });
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => { throw new DOMException("SecurityError"); });
+    expect(() => MultiWalletStorage.addWallet(USER_A, makeWalletInput())).toThrow(MultiWalletStorageError);
+  });
+
+  it("throws STORAGE_FULL when quota is exceeded on setItem", () => {
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput()); // first call seeds getAll via getItem mock
+    expect(() =>
+      MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2" }))
+    ).toThrow(MultiWalletStorageError);
+  });
+});
+
+// ─── removeWallet ─────────────────────────────────────────────────────────────
+
+describe("MultiWalletStorage.removeWallet", () => {
+  it("removes the specified wallet", () => {
+    const w = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2" }));
+    MultiWalletStorage.removeWallet(USER_A, w.id);
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all.find((x) => x.id === w.id)).toBeUndefined();
+    expect(all).toHaveLength(1);
+  });
+
+  it("re-assigns isActive to another wallet when active wallet is removed", () => {
+    const first = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    // first is active by default (it's the first wallet)
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2", isActive: false }));
+    MultiWalletStorage.removeWallet(USER_A, first.id);
+    const remaining = MultiWalletStorage.getAll(USER_A);
+    expect(remaining[0].isActive).toBe(true);
+  });
+
+  it("re-assigns isPrimary to another wallet when primary wallet is removed", () => {
+    const first = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2", isPrimary: false }));
+    MultiWalletStorage.removeWallet(USER_A, first.id);
+    const remaining = MultiWalletStorage.getAll(USER_A);
+    expect(remaining[0].isPrimary).toBe(true);
+  });
+
+  it("removing the only wallet results in an empty list", () => {
+    const w = MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    MultiWalletStorage.removeWallet(USER_A, w.id);
+    expect(MultiWalletStorage.getAll(USER_A)).toHaveLength(0);
+  });
+
+  it("removing a non-existent wallet id is a no-op", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    expect(() => MultiWalletStorage.removeWallet(USER_A, "does_not_exist")).not.toThrow();
+    expect(MultiWalletStorage.getAll(USER_A)).toHaveLength(1);
+  });
+});
+
+// ─── setActiveWallet (switch primary wallet) ──────────────────────────────────
+
+describe("MultiWalletStorage.setActiveWallet", () => {
+  it("sets the target wallet as active and deactivates all others", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    const second = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2", isActive: false }));
+    MultiWalletStorage.setActiveWallet(USER_A, second.id);
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all.find((w) => w.id === second.id)!.isActive).toBe(true);
+    expect(all.filter((w) => w.isActive)).toHaveLength(1);
+  });
+
+  it("updates lastUsedAt on the activated wallet", () => {
+    const before = new Date(Date.now() - 5000).toISOString();
+    const first = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    // Manually set an old lastUsedAt
+    const stored = MultiWalletStorage.getAll(USER_A);
+    stored[0].lastUsedAt = before;
+    lsMock.store[walletKey(USER_A)] = JSON.stringify(stored);
+
+    MultiWalletStorage.setActiveWallet(USER_A, first.id);
+    const updated = MultiWalletStorage.getAll(USER_A)[0];
+    expect(updated.lastUsedAt > before).toBe(true);
+  });
+
+  it("throws WALLET_NOT_FOUND for unknown walletId", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    expect(() => MultiWalletStorage.setActiveWallet(USER_A, "ghost_id")).toThrow(MultiWalletStorageError);
+  });
+});
+
+// ─── getWalletData ────────────────────────────────────────────────────────────
+
+describe("MultiWalletStorage.getWalletData", () => {
+  it("returns activeWallet and primaryWallet correctly", () => {
+    const first = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_1" }));
+    const second = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "KEY_2", isActive: true }));
+    const data = MultiWalletStorage.getWalletData(USER_A);
+    expect(data.activeWallet?.id).toBe(second.id);
+    expect(data.primaryWallet?.id).toBe(first.id);
+  });
+
+  it("returns null activeWallet and primaryWallet for empty store", () => {
+    const data = MultiWalletStorage.getWalletData(USER_A);
+    expect(data.activeWallet).toBeNull();
+    expect(data.primaryWallet).toBeNull();
+    expect(data.wallets).toHaveLength(0);
+  });
+});
+
+// ─── migrateFromSingleWallet ──────────────────────────────────────────────────
+
+describe("MultiWalletStorage.migrateFromSingleWallet", () => {
+  it("creates an embedded primary wallet from single-wallet data", () => {
+    const result = MultiWalletStorage.migrateFromSingleWallet(USER_A, {
+      publicKey: "STELLAR_KEY",
+      walletType: "embedded",
+      network: "testnet",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.publicKey).toBe("STELLAR_KEY");
+    expect(result!.isPrimary).toBe(true);
+    expect(result!.isActive).toBe(true);
+  });
+
+  it("returns null when wallets already exist (already migrated)", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    const result = MultiWalletStorage.migrateFromSingleWallet(USER_A, {
+      publicKey: "ANOTHER_KEY",
+      walletType: "metamask",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("stores the secret key encoded when provided", () => {
+    const secret = "STEST_SECRET_KEY";
+    MultiWalletStorage.migrateFromSingleWallet(USER_A, {
+      publicKey: "G_KEY",
+      secretKey: secret,
+      walletType: "imported",
+    });
+    // getSecretKey should decode it back
+    const wallets = MultiWalletStorage.getAll(USER_A);
+    const retrieved = MultiWalletStorage.getSecretKey(USER_A, wallets[0].id);
+    expect(retrieved).toBe(secret);
+  });
+
+  it("does not store _encodedSecret when no secretKey is provided", () => {
+    MultiWalletStorage.migrateFromSingleWallet(USER_A, {
+      publicKey: "G_KEY",
+      walletType: "freighter",
+    });
+    const wallets = MultiWalletStorage.getAll(USER_A);
+    expect(wallets[0]._encodedSecret).toBeUndefined();
+  });
+});
+
+// ─── clearAll ─────────────────────────────────────────────────────────────────
+
+describe("MultiWalletStorage.clearAll", () => {
+  it("removes all wallets for a user", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    MultiWalletStorage.clearAll(USER_A);
+    expect(MultiWalletStorage.getAll(USER_A)).toHaveLength(0);
+  });
+
+  it("does not affect wallets for other users", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput());
+    MultiWalletStorage.addWallet(USER_B, makeWalletInput({ publicKey: "B_KEY" }));
+    MultiWalletStorage.clearAll(USER_A);
+    expect(MultiWalletStorage.getAll(USER_B)).toHaveLength(1);
+  });
+});
+
+// ─── Concurrent add/remove consistency ───────────────────────────────────────
+
+describe("Concurrent add/remove consistency", () => {
+  it("multiple sequential addWallet calls result in correct count", () => {
+    for (let i = 0; i < 10; i++) {
+      MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: `KEY_${i}` }));
+    }
+    expect(MultiWalletStorage.getAll(USER_A)).toHaveLength(10);
+  });
+
+  it("interleaved add and remove keeps the store consistent", () => {
+    const w1 = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K1" }));
+    const w2 = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K2" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K3" }));
+    MultiWalletStorage.removeWallet(USER_A, w1.id);
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K4" }));
+    MultiWalletStorage.removeWallet(USER_A, w2.id);
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all).toHaveLength(2);
+    expect(all.map((w) => w.publicKey)).toEqual(expect.arrayContaining(["K3", "K4"]));
+  });
+
+  it("exactly one wallet is active after a series of addWallet calls", () => {
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K1" }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K2", isActive: true }));
+    MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K3", isActive: true }));
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all.filter((w) => w.isActive)).toHaveLength(1);
+  });
+
+  it("exactly one wallet is primary after multiple setPrimary calls", () => {
+    const w1 = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K1" }));
+    const w2 = MultiWalletStorage.addWallet(USER_A, makeWalletInput({ publicKey: "K2" }));
+    MultiWalletStorage.updateWallet(USER_A, w2.id, { isPrimary: true });
+    MultiWalletStorage.updateWallet(USER_A, w1.id, { isPrimary: true });
+    const all = MultiWalletStorage.getAll(USER_A);
+    expect(all.filter((w) => w.isPrimary)).toHaveLength(1);
+    expect(all.find((w) => w.isPrimary)!.id).toBe(w1.id);
+  });
+});

--- a/clips-frontend/app/api/upload/route.ts
+++ b/clips-frontend/app/api/upload/route.ts
@@ -1,21 +1,44 @@
-import { NextRequest, NextResponse } from "next/server";
+/**
+ * /api/upload/route.ts — Issue #442
+ *
+ * Real cloud-storage upload endpoint.
+ *
+ * Files are validated, converted to a Buffer, then stored in the configured
+ * S3-compatible bucket (AWS S3, Cloudflare R2, or GCS S3 interop) via
+ * app/lib/cloudStorage.ts.  The response includes a stable jobId tied to the
+ * stored object so downstream AI processing can reference it.
+ *
+ * File size limit: 500 MB (hard-rejected before any storage call).
+ *
+ * Environment variables required (see app/lib/cloudStorage.ts for full list):
+ *   CLOUD_STORAGE_BUCKET, CLOUD_STORAGE_REGION, AWS_ACCESS_KEY_ID,
+ *   AWS_SECRET_ACCESS_KEY
+ *
+ * Optional:
+ *   CLOUD_STORAGE_ENDPOINT   — for R2 / GCS S3 interop
+ *   CLOUD_STORAGE_KEY_PREFIX — object key prefix (default: "uploads/")
+ *
+ * Malware scanning:
+ *   Full malware scanning (ClamAV / third-party API) is a future requirement.
+ *   Files are currently stored unscanned.  See docs/SECURITY.md for the
+ *   planned scanning integration.
+ */
 
-const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB
+import { NextRequest, NextResponse } from "next/server";
+import { uploadFile } from "@/app/lib/cloudStorage";
+
+const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
 const ALLOWED_TYPES = ["video/mp4", "video/quicktime", "video/x-msvideo", "video/x-matroska"];
 const ALLOWED_EXTENSIONS = [".mp4", ".mov", ".avi", ".mkv"];
 
 function validateFile(file: File): string | null {
-  // Check file size
   if (file.size > MAX_FILE_SIZE) {
-    return `File "${file.name}" exceeds maximum size of 500MB`;
+    return `File "${file.name}" exceeds the maximum allowed size of 500 MB`;
   }
-
-  // Check file type
-  const extension = "." + file.name.split(".").pop()?.toLowerCase();
-  if (!ALLOWED_TYPES.includes(file.type) && !ALLOWED_EXTENSIONS.includes(extension)) {
-    return `File "${file.name}" has unsupported format. Allowed: MP4, MOV, AVI, MKV`;
+  const ext = "." + (file.name.split(".").pop()?.toLowerCase() ?? "");
+  if (!ALLOWED_TYPES.includes(file.type) && !ALLOWED_EXTENSIONS.includes(ext)) {
+    return `File "${file.name}" has an unsupported format. Allowed: MP4, MOV, AVI, MKV`;
   }
-
   return null;
 }
 
@@ -25,49 +48,57 @@ export async function POST(request: NextRequest) {
     const files = formData.getAll("files") as File[];
 
     if (!files || files.length === 0) {
-      return NextResponse.json(
-        { error: "No files provided" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "No files provided" }, { status: 400 });
     }
 
-    // Validate all files
-    const errors: string[] = [];
+    // Validate every file before touching storage
+    const validationErrors: string[] = [];
     for (const file of files) {
-      const error = validateFile(file);
-      if (error) {
-        errors.push(error);
-      }
+      const err = validateFile(file);
+      if (err) validationErrors.push(err);
     }
-
-    if (errors.length > 0) {
+    if (validationErrors.length > 0) {
       return NextResponse.json(
-        { error: errors.join("; ") },
+        { error: validationErrors.join("; ") },
         { status: 400 }
       );
     }
 
-    // Simulate file processing - in production, this would:
-    // 1. Upload to cloud storage (S3, etc.)
-    // 2. Create a processing job
-    // 3. Return job ID for polling
+    // Upload all files to cloud storage
+    const results = await Promise.all(
+      files.map(async (file) => {
+        const arrayBuffer = await file.arrayBuffer();
+        const buffer = Buffer.from(arrayBuffer);
+        return uploadFile(buffer, file.name, file.type || "application/octet-stream");
+      })
+    );
 
-    const jobId = `job_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-
-    // Simulate processing delay
-    // In production, the upload would be handled async
+    // Return the first jobId as the primary reference (for single-file flows)
+    const primaryJobId = results[0].jobId;
 
     return NextResponse.json({
       success: true,
       message: `Successfully uploaded ${files.length} file(s)`,
-      jobId,
-      files: files.map((f) => ({
-        name: f.name,
-        size: f.size,
-        type: f.type,
+      jobId: primaryJobId,
+      files: results.map((r) => ({
+        name: r.filename,
+        size: r.size,
+        type: r.contentType,
+        jobId: r.jobId,
+        objectKey: r.objectKey,
+        url: r.url,
       })),
     });
-  } catch (error) {
+  } catch (error: unknown) {
+    // Differentiate configuration errors from runtime errors
+    if (error instanceof Error && error.message.startsWith("Missing required environment variable")) {
+      console.error("Upload config error:", error.message);
+      return NextResponse.json(
+        { error: "Cloud storage is not configured. Contact support." },
+        { status: 503 }
+      );
+    }
+
     console.error("Upload error:", error);
     return NextResponse.json(
       { error: "Internal server error during upload" },

--- a/clips-frontend/app/lib/cloudStorage.ts
+++ b/clips-frontend/app/lib/cloudStorage.ts
@@ -1,0 +1,186 @@
+/**
+ * cloudStorage.ts — Issue #442
+ *
+ * Thin abstraction over S3-compatible cloud storage (AWS S3, GCS via S3
+ * interop, or Cloudflare R2).  The active backend is determined entirely by
+ * environment variables so no code changes are needed to switch providers.
+ *
+ * Required env vars:
+ *   CLOUD_STORAGE_PROVIDER   — "s3" | "r2" | "gcs"  (default: "s3")
+ *   CLOUD_STORAGE_BUCKET     — bucket name
+ *   CLOUD_STORAGE_REGION     — region (e.g. "us-east-1"; R2 uses "auto")
+ *   CLOUD_STORAGE_ENDPOINT   — custom endpoint URL (required for R2 / GCS S3)
+ *   AWS_ACCESS_KEY_ID        — access key / account ID
+ *   AWS_SECRET_ACCESS_KEY    — secret key / API token
+ *
+ * Optional:
+ *   CLOUD_STORAGE_KEY_PREFIX — prefix prepended to all object keys (default: "uploads/")
+ */
+
+import {
+  S3Client,
+  PutObjectCommand,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+  AbortMultipartUploadCommand,
+} from "@aws-sdk/client-s3";
+import { randomUUID } from "crypto";
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) throw new Error(`Missing required environment variable: ${name}`);
+  return val;
+}
+
+function buildS3Client(): S3Client {
+  const endpoint = process.env.CLOUD_STORAGE_ENDPOINT;
+  return new S3Client({
+    region: process.env.CLOUD_STORAGE_REGION ?? "us-east-1",
+    ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+    credentials: {
+      accessKeyId: requireEnv("AWS_ACCESS_KEY_ID"),
+      secretAccessKey: requireEnv("AWS_SECRET_ACCESS_KEY"),
+    },
+  });
+}
+
+const BUCKET = () => requireEnv("CLOUD_STORAGE_BUCKET");
+const KEY_PREFIX = process.env.CLOUD_STORAGE_KEY_PREFIX ?? "uploads/";
+
+// Multipart threshold: files larger than 50 MB use multipart upload.
+const MULTIPART_THRESHOLD = 50 * 1024 * 1024; // 50 MB
+// Part size for multipart: 10 MB minimum per S3 spec.
+const PART_SIZE = 10 * 1024 * 1024; // 10 MB
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface UploadResult {
+  /** Stable job ID tied to this specific upload */
+  jobId: string;
+  /** Full object key in the bucket */
+  objectKey: string;
+  /** Public or pre-signed URL (if bucket is public) */
+  url: string;
+  /** Original filename */
+  filename: string;
+  /** File size in bytes */
+  size: number;
+  /** MIME type */
+  contentType: string;
+}
+
+// ─── Single-part upload (<= MULTIPART_THRESHOLD) ─────────────────────────────
+
+async function uploadSinglePart(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  buffer: Buffer,
+  contentType: string,
+): Promise<void> {
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: buffer,
+      ContentType: contentType,
+      ContentLength: buffer.length,
+    }),
+  );
+}
+
+// ─── Multipart upload (> MULTIPART_THRESHOLD) ─────────────────────────────────
+
+async function uploadMultipart(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  buffer: Buffer,
+  contentType: string,
+): Promise<void> {
+  const { UploadId } = await client.send(
+    new CreateMultipartUploadCommand({
+      Bucket: bucket,
+      Key: key,
+      ContentType: contentType,
+    }),
+  );
+
+  if (!UploadId) throw new Error("Failed to create multipart upload");
+
+  const parts: { ETag: string; PartNumber: number }[] = [];
+
+  try {
+    let partNumber = 1;
+    for (let offset = 0; offset < buffer.length; offset += PART_SIZE) {
+      const chunk = buffer.slice(offset, offset + PART_SIZE);
+      const { ETag } = await client.send(
+        new UploadPartCommand({
+          Bucket: bucket,
+          Key: key,
+          UploadId,
+          PartNumber: partNumber,
+          Body: chunk,
+          ContentLength: chunk.length,
+        }),
+      );
+      if (!ETag) throw new Error(`Missing ETag for part ${partNumber}`);
+      parts.push({ ETag, PartNumber: partNumber });
+      partNumber++;
+    }
+
+    await client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId,
+        MultipartUpload: { Parts: parts },
+      }),
+    );
+  } catch (err) {
+    // Abort the incomplete multipart upload to avoid orphaned storage costs.
+    await client
+      .send(new AbortMultipartUploadCommand({ Bucket: bucket, Key: key, UploadId }))
+      .catch(() => {});
+    throw err;
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Upload a file buffer to cloud storage.
+ *
+ * - Files ≤ 50 MB use a single PutObject request.
+ * - Files > 50 MB use multipart upload (10 MB parts).
+ * - Returns an UploadResult with a stable jobId.
+ */
+export async function uploadFile(
+  buffer: Buffer,
+  filename: string,
+  contentType: string,
+): Promise<UploadResult> {
+  const client = buildS3Client();
+  const bucket = BUCKET();
+
+  const jobId = `job_${randomUUID().replace(/-/g, "")}`;
+  const ext = filename.split(".").pop() ?? "bin";
+  const objectKey = `${KEY_PREFIX}${jobId}.${ext}`;
+
+  if (buffer.length > MULTIPART_THRESHOLD) {
+    await uploadMultipart(client, bucket, objectKey, buffer, contentType);
+  } else {
+    await uploadSinglePart(client, bucket, objectKey, buffer, contentType);
+  }
+
+  const endpoint = process.env.CLOUD_STORAGE_ENDPOINT;
+  const region = process.env.CLOUD_STORAGE_REGION ?? "us-east-1";
+  const url = endpoint
+    ? `${endpoint.replace(/\/$/, "")}/${bucket}/${objectKey}`
+    : `https://${bucket}.s3.${region}.amazonaws.com/${objectKey}`;
+
+  return { jobId, objectKey, url, filename, size: buffer.length, contentType };
+}

--- a/clips-frontend/package.json
+++ b/clips-frontend/package.json
@@ -15,6 +15,7 @@
     "changeset": "changeset"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.637.0",
     "@sentry/nextjs": "^10.55.0",
     "@sentry/types": "^10.55.0",
     "@stellar/stellar-sdk": "^15.1.0",


### PR DESCRIPTION
closes #436
closes #442

## Summary

### closes #436 — Unit tests for multi-wallet CRUD operations and provider state

**`__tests__/lib/multiWalletStorage.test.ts`**
Storage is mocked via `jest.spyOn(Storage.prototype, ...)` with an in-memory store. Covers:
- `getAll`: empty store, user isolation, insertion order, malformed JSON graceful
- `addWallet`: first-wallet auto-primary/active, id/timestamp generation, localStorage write, deactivate-on-active, unmark-primary, `STORAGE_UNAVAILABLE` and `STORAGE_FULL` errors
- `removeWallet`: correct removal, active/primary re-assignment, single-wallet clear, no-op for unknown id
- `setActiveWallet`: deactivates previous, updates `lastUsedAt`, `WALLET_NOT_FOUND`
- `getWalletData`: correct `activeWallet`/`primaryWallet` resolution
- `migrateFromSingleWallet`: creates primary wallet, idempotent, encodes secret, omits `_encodedSecret` when absent
- `clearAll`: user isolation
- **Concurrent consistency**: 10 sequential adds, interleaved add/remove, exactly one active, exactly one primary after multiple flag-setting calls

**`__tests__/components/MultiWalletProvider.test.tsx`**
All side-effect modules (`AuthProvider`, `analytics`, `walletErrorTracking`) are mocked. Covers:
- Initial state (empty, nulls, no error)
- `addWallet`: state update, auto-primary on first, analytics event, error on storage throw
- `removeWallet`: non-primary removed, primary blocked with error message
- `switchWallet`: `activeWallet` reflects new wallet, analytics event
- `setPrimaryWallet`: single primary invariant
- `clearError`: resets error state
- `refreshWallets`: re-reads after external storage write
- `migrateToMultiWallet` helper: creates wallet, idempotent

### closes #442 — Replace mock upload API with real cloud storage

**`app/lib/cloudStorage.ts`** (new)
- `buildS3Client()`: constructs `@aws-sdk/client-s3` S3Client from env vars; supports AWS S3, Cloudflare R2 (custom endpoint + `forcePathStyle`), GCS S3 interop
- `uploadFile()`: auto-selects single-part (`PutObject`, ≤ 50 MB) or multipart (10 MB parts, > 50 MB); aborts incomplete multipart on error
- Returns `UploadResult` with stable `jobId` (`crypto.randomUUID`), `objectKey`, `url`, `filename`, `size`, `contentType`

**`app/api/upload/route.ts`** (updated)
- Removes fake `jobId` and simulated delay
- Validates all files first (500 MB limit + MIME/extension allowlist)
- Uploads all files in parallel (`Promise.all`)
- Returns per-file `jobId` so AI pipeline can reference individual uploads
- 503 for missing env vars, 500 for other runtime errors

**`.env.example`** (new) — documents `CLOUD_STORAGE_BUCKET`, `CLOUD_STORAGE_REGION`, `CLOUD_STORAGE_ENDPOINT`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `CLOUD_STORAGE_KEY_PREFIX`

**`package.json`**: adds `@aws-sdk/client-s3 ^3.637.0`

**Malware scanning**: documented as a future requirement via inline comment in `route.ts`. Files are stored unscanned pending ClamAV / third-party API integration.

## Test plan
- [ ] `npm test -- __tests__/lib/multiWalletStorage.test.ts` — all storage tests pass
- [ ] `npm test -- __tests__/components/MultiWalletProvider.test.tsx` — all provider tests pass
- [ ] Set env vars from `.env.example`, upload a valid MP4 — response contains real `jobId` and `objectKey`
- [ ] Upload a 501 MB file — returns 400 with clear size error
- [ ] Upload an unsupported file type — returns 400 with format error
- [ ] Remove all env vars — returns 503 "not configured" (not a 500 stack trace)