### PR TITLE
fix: resolve issues #514 #519 #520 #521

### DIFF
--- a/__tests__/earnings/earnings-pagination.test.ts
+++ b/__tests__/earnings/earnings-pagination.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Pagination boundary tests for getEarningsReport and /api/earnings
+ * Covers: first page, last page, empty results, page clamping
+ */
+
+import { getEarningsReport } from "@/app/lib/mockApi";
+
+// Bypass rate limiter by calling the unwrapped function via the rateLimiter wrapper
+// The mock just calls through synchronously
+
+jest.mock("@/app/lib/rateLimiter", () => ({
+  rateLimiter: (fn: any) => fn,
+}));
+
+// Re-import after mock
+let getReport: typeof getEarningsReport;
+
+beforeAll(async () => {
+  jest.resetModules();
+  jest.mock("@/app/lib/rateLimiter", () => ({
+    rateLimiter: (fn: any) => fn,
+  }));
+  const mod = await import("@/app/lib/mockApi");
+  getReport = mod.getEarningsReport as any;
+});
+
+describe("getEarningsReport — pagination", () => {
+  it("first page returns pageSize items and correct pagination metadata", async () => {
+    const result = await getReport("user1", { page: 1, pageSize: 10 });
+
+    expect(result.transactions).toHaveLength(10);
+    expect(result.pagination.page).toBe(1);
+    expect(result.pagination.pageSize).toBe(10);
+    expect(result.pagination.total).toBe(55);
+    expect(result.pagination.totalPages).toBe(6); // ceil(55/10)
+  });
+
+  it("last page returns the remaining items", async () => {
+    // 55 items, pageSize=10 → page 6 has 5 items
+    const result = await getReport("user1", { page: 6, pageSize: 10 });
+
+    expect(result.transactions).toHaveLength(5);
+    expect(result.pagination.page).toBe(6);
+    expect(result.pagination.totalPages).toBe(6);
+  });
+
+  it("page beyond total is clamped to last page", async () => {
+    const result = await getReport("user1", { page: 999, pageSize: 20 });
+
+    expect(result.pagination.page).toBeLessThanOrEqual(result.pagination.totalPages);
+    expect(result.transactions.length).toBeGreaterThan(0);
+  });
+
+  it("default page=1, pageSize=20 returns first 20 items", async () => {
+    const result = await getReport("user1");
+
+    expect(result.transactions).toHaveLength(20);
+    expect(result.pagination.page).toBe(1);
+    expect(result.pagination.pageSize).toBe(20);
+    expect(result.pagination.totalPages).toBe(3); // ceil(55/20)
+  });
+
+  it("page 2 returns next slice of items", async () => {
+    const page1 = await getReport("user1", { page: 1, pageSize: 20 });
+    const page2 = await getReport("user1", { page: 2, pageSize: 20 });
+
+    // Pages must not overlap (different IDs)
+    const ids1 = new Set(page1.transactions.map((t) => t.id));
+    const ids2 = new Set(page2.transactions.map((t) => t.id));
+    const overlap = [...ids1].filter((id) => ids2.has(id));
+    expect(overlap).toHaveLength(0);
+  });
+
+  it("summary totals are computed over all transactions, not just the current page", async () => {
+    // A page of 5 items cannot have a total that equals only those 5 items
+    // because the total is the sum of all 55 transactions.
+    const result = await getReport("user1", { page: 1, pageSize: 5 });
+
+    const pageTotal = result.transactions.reduce((sum, t) => sum + t.amount, 0);
+    const reportedTotal = parseFloat(result.summary.total);
+
+    // The reported total must be greater than just the 5 items on this page
+    expect(reportedTotal).toBeGreaterThan(pageTotal);
+
+    // And the pagination reflects the full 55
+    expect(result.pagination.total).toBe(55);
+  });
+});
+
+describe("getEarningsReport — edge cases", () => {
+  it("pageSize=1 returns exactly 1 transaction per page", async () => {
+    const result = await getReport("user1", { page: 1, pageSize: 1 });
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.pagination.totalPages).toBe(55);
+  });
+
+  it("pageSize larger than total returns all items on page 1", async () => {
+    const result = await getReport("user1", { page: 1, pageSize: 200 });
+
+    expect(result.transactions).toHaveLength(55);
+    expect(result.pagination.totalPages).toBe(1);
+  });
+
+  it("pagination metadata has consistent shape", async () => {
+    const result = await getReport("user1", { page: 2, pageSize: 15 });
+
+    expect(result.pagination).toMatchObject({
+      page: 2,
+      pageSize: 15,
+      total: 55,
+      totalPages: 4, // ceil(55/15)
+    });
+  });
+});

--- a/__tests__/hooks/useMultiWalletConnection.test.tsx
+++ b/__tests__/hooks/useMultiWalletConnection.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * Tests for useMultiWalletConnection — Issue #514
+ *
+ * Verifies the race-condition fix:
+ *   - connectMetaMask / connectPhantom use the address returned by the
+ *     connect promise rather than stale context state.
+ *   - When the connect method returns null (simulated old/broken provider),
+ *     the hook falls back to polling wallet.address from context.
+ *   - The address is captured correctly without requiring a second render cycle.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useMultiWalletConnection } from "@/app/hooks/useMultiWalletConnection";
+
+// ─── Mock providers ───────────────────────────────────────────────────────────
+
+const MOCK_USER = { id: "user_123", email: "test@example.com" };
+
+// Track calls to addWallet
+const mockAddWallet = jest.fn();
+const mockMultiWallet = {
+  wallets: [],
+  activeWallet: null,
+  primaryWallet: null,
+  isOperating: false,
+  error: null,
+  addWallet: mockAddWallet,
+  removeWallet: jest.fn(),
+  switchWallet: jest.fn(),
+  setPrimaryWallet: jest.fn(),
+  updateWallet: jest.fn(),
+  refreshWallets: jest.fn(),
+  clearError: jest.fn(),
+};
+
+jest.mock("@/components/AuthProvider", () => ({
+  useAuth: jest.fn(() => ({ user: MOCK_USER })),
+}));
+
+jest.mock("@/components/MultiWalletProvider", () => ({
+  useMultiWallet: jest.fn(() => mockMultiWallet),
+  migrateToMultiWallet: jest.fn(),
+}));
+
+// WalletProvider mock — configurable per test
+const mockWalletState: {
+  address: string | null;
+  chainId: string | null;
+  walletType: string | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: string | null;
+  stellarSecret: string | null;
+  connectMetaMask: jest.Mock;
+  connectPhantom: jest.Mock;
+  connectStellar: jest.Mock;
+  importStellarKey: jest.Mock;
+  disconnect: jest.Mock;
+  clearError: jest.Mock;
+} = {
+  address: null,
+  chainId: null,
+  walletType: null,
+  isConnected: false,
+  isConnecting: false,
+  error: null,
+  stellarSecret: null,
+  connectMetaMask: jest.fn(),
+  connectPhantom: jest.fn(),
+  connectStellar: jest.fn(),
+  importStellarKey: jest.fn(),
+  disconnect: jest.fn(),
+  clearError: jest.fn(),
+};
+
+jest.mock("@/components/WalletProvider", () => ({
+  useWallet: jest.fn(() => mockWalletState),
+}));
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWalletState.address = null;
+  mockWalletState.chainId = null;
+  mockWalletState.walletType = null;
+  mockWalletState.isConnected = false;
+  mockAddWallet.mockResolvedValue({ id: "wallet_1", publicKey: "0xABC" });
+});
+
+// ─── Race condition fix: address from returned promise ───────────────────────
+
+describe("connectMetaMask — uses returned address (issue #514)", () => {
+  it("passes the address returned by the connect promise to addWallet", async () => {
+    const EXPECTED_ADDRESS = "0x1234567890abcdef";
+
+    // Connect promise returns the address — context is NOT yet updated
+    mockWalletState.connectMetaMask.mockResolvedValue(EXPECTED_ADDRESS);
+    // wallet.address in context remains null (the race condition scenario)
+    mockWalletState.address = null;
+
+    const { result } = renderHook(() => useMultiWalletConnection());
+
+    await act(async () => {
+      await result.current.connectMetaMask();
+    });
+
+    expect(mockAddWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: EXPECTED_ADDRESS, walletType: "metamask" })
+    );
+  });
+
+  it("captures the address without a second render cycle", async () => {
+    const EXPECTED_ADDRESS = "0xdeadbeef";
+    mockWalletState.connectMetaMask.mockResolvedValue(EXPECTED_ADDRESS);
+    // Never update wallet.address — simulates context not having re-rendered
+    mockWalletState.address = null;
+
+    const { result } = renderHook(() => useMultiWalletConnection());
+    let addWalletCalledAt: number | null = null;
+
+    mockAddWallet.mockImplementation(async (data: { publicKey: string }) => {
+      addWalletCalledAt = Date.now();
+      return { id: "w1", publicKey: data.publicKey };
+    });
+
+    await act(async () => {
+      await result.current.connectMetaMask();
+    });
+
+    // addWallet must have been called with the correct address
+    expect(mockAddWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: EXPECTED_ADDRESS })
+    );
+    expect(addWalletCalledAt).not.toBeNull();
+  });
+
+  it("does NOT call addWallet when connect returns null and context never updates", async () => {
+    // Simulate a broken provider that returns null and never updates context
+    mockWalletState.connectMetaMask.mockResolvedValue(null);
+    mockWalletState.address = null; // context also null
+
+    const { result } = renderHook(() => useMultiWalletConnection());
+
+    await act(async () => {
+      await result.current.connectMetaMask();
+    });
+
+    expect(mockAddWallet).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Fallback poll ────────────────────────────────────────────────────────────
+
+describe("connectMetaMask — polling fallback when connect returns null", () => {
+  it("uses context address when connect returns null but context updates async", async () => {
+    const POLLED_ADDRESS = "0xpolled_address";
+    const { useWallet } = require("@/components/WalletProvider");
+
+    // Phase 1: connect returns null; wallet.address is null
+    mockWalletState.connectMetaMask.mockResolvedValue(null);
+    mockWalletState.address = null;
+
+    // Simulate a re-render that updates wallet.address ~60ms after connect
+    // by swapping the useWallet return value and triggering a re-render.
+    let triggerAddressUpdate: (() => void) | null = null;
+    const connectPromise = new Promise<void>((resolve) => {
+      triggerAddressUpdate = resolve;
+    });
+
+    // Override connectMetaMask to: return null, then schedule the address update
+    mockWalletState.connectMetaMask.mockImplementation(async () => {
+      setTimeout(() => {
+        mockWalletState.address = POLLED_ADDRESS;
+        triggerAddressUpdate?.();
+      }, 60);
+      return null;
+    });
+
+    useWallet.mockImplementation(() => ({ ...mockWalletState }));
+
+    const { result, rerender } = renderHook(() => useMultiWalletConnection());
+
+    // Start the connect (don't await yet — let the timeout fire while polling)
+    let connectDone = false;
+    act(() => {
+      result.current.connectMetaMask().then(() => { connectDone = true; });
+    });
+
+    // Wait for the timeout to fire and update the address
+    await connectPromise;
+
+    // Re-render so the hook's useEffect picks up the new wallet.address
+    rerender();
+
+    // Now wait for connect to finish (it polls 50ms × 20)
+    await waitFor(() => expect(connectDone).toBe(true), { timeout: 2000 });
+
+    expect(mockAddWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: POLLED_ADDRESS })
+    );
+  });
+});
+
+// ─── connectPhantom ───────────────────────────────────────────────────────────
+
+describe("connectPhantom — uses returned address", () => {
+  it("passes the address returned by the connect promise to addWallet", async () => {
+    const PHANTOM_ADDRESS = "SolanaPublicKeyBase58XYZ";
+    mockWalletState.connectPhantom.mockResolvedValue(PHANTOM_ADDRESS);
+    mockWalletState.address = null; // context not yet updated
+
+    const { result } = renderHook(() => useMultiWalletConnection());
+
+    await act(async () => {
+      await result.current.connectPhantom();
+    });
+
+    expect(mockAddWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: PHANTOM_ADDRESS, walletType: "phantom" })
+    );
+  });
+});
+
+// ─── importStellarKey ─────────────────────────────────────────────────────────
+
+describe("importStellarKey — uses returned address", () => {
+  it("passes the address returned by the import to addWallet", async () => {
+    const STELLAR_ADDRESS = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBFCNKUYZAKK3PJQHFXCX";
+    mockWalletState.importStellarKey.mockResolvedValue(STELLAR_ADDRESS);
+    mockWalletState.address = null;
+
+    const { result } = renderHook(() => useMultiWalletConnection());
+
+    await act(async () => {
+      await result.current.importStellarKey("SECRET_KEY");
+    });
+
+    expect(mockAddWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: STELLAR_ADDRESS, walletType: "imported" })
+    );
+  });
+});

--- a/app/api/earnings/route.ts
+++ b/app/api/earnings/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getEarningsReport } from "@/app/lib/mockApi";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
+  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10) || 20));
+
+  // userId would come from the session in production; use a placeholder here
+  const userId = "api-user";
+
+  try {
+    const data = await getEarningsReport(userId, { page, pageSize });
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/dashboard/processing/page.tsx
+++ b/app/dashboard/processing/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import ProcessingHeader from "@/components/dashboard/ProcessingHeader";
 import { Sparkles, Clock, Zap, RefreshCw, X, CheckCircle, AlertCircle, RotateCcw } from "lucide-react";
-import { useProcessStore, selectProcess } from "@/app/store/processStore";
+import { useProcessStore, selectProcess, selectHasHydrated } from "@/app/store/processStore";
 import { useProcessingStatus } from "@/app/hooks/useProcessingStatus";
 import { ProcessStatus } from "@/app/store/types";
 
@@ -24,6 +24,7 @@ export default function ProcessingPage() {
   const [notificationSent, setNotificationSent] = useState(false);
 
   const process = useProcessStore(selectProcess);
+  const hasHydrated = useProcessStore(selectHasHydrated);
   const { progress, momentsFound, estimatedSecondsRemaining, status, id } = process;
   const resetProcess = useProcessStore((s) => s.resetProcess);
 
@@ -62,6 +63,15 @@ export default function ProcessingPage() {
     setNotificationSent(false);
     router.push("/dashboard");
   };
+
+  // Loading — wait for async secureStorage rehydration
+  if (!hasHydrated) {
+    return (
+      <div className="min-h-screen bg-background text-white flex items-center justify-center">
+        <div className="w-8 h-8 rounded-full border-2 border-brand border-t-transparent animate-spin" />
+      </div>
+    );
+  }
 
   // Success state
   if (status === "complete") {

--- a/app/earnings/page.tsx
+++ b/app/earnings/page.tsx
@@ -17,6 +17,7 @@ import {
 import { MockApi, type Summary, type Transaction } from "@/app/lib/mockApi";
 import { useAuth } from "@/components/AuthProvider";
 import analytics from "@/lib/analytics";
+import { useFilterQueryState } from "@/hooks/useFilterQueryState";
 
 type ExportFormat = "csv" | "json" | "pdf";
 
@@ -83,18 +84,23 @@ export default function EarningsPage() {
   });
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [filteredTransactions, setFilteredTransactions] = useState<Transaction[]>([]);
+  const [pagination, setPagination] = useState<{ page: number; pageSize: number; total: number; totalPages: number } | undefined>();
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
   const { user } = useAuth();
+
+  const { filters, updateFilters } = useFilterQueryState({ page: 1, pageSize: 20 });
+  const { page, pageSize } = filters;
 
   useEffect(() => {
     async function loadData() {
       if (!user?.id) return;
       try {
         setLoading(true);
-        const data = await MockApi.getEarningsReport(user.id);
+        const data = await MockApi.getEarningsReport(user.id, { page, pageSize });
         setSummary(data.summary);
         setTransactions(data.transactions);
+        setPagination(data.pagination);
       } catch (error) {
         console.error("Failed to load earnings summary:", error);
       } finally {
@@ -102,7 +108,7 @@ export default function EarningsPage() {
       }
     }
     loadData();
-  }, [user?.id]);
+  }, [user?.id, page, pageSize]);
 
   const exportCSV = async (format: "csv" | "json" | "pdf") => {
     const exportData = filteredTransactions.length > 0 ? filteredTransactions : transactions;
@@ -294,6 +300,8 @@ export default function EarningsPage() {
           summary={summary}
           loading={loading}
           onFilteredTransactionsChange={setFilteredTransactions}
+          pagination={pagination}
+          onPageChange={(p) => updateFilters({ page: p })}
         />
       </div>
     </EarningsLayout>

--- a/app/hooks/useMultiWalletConnection.ts
+++ b/app/hooks/useMultiWalletConnection.ts
@@ -2,56 +2,109 @@
  * useMultiWalletConnection.ts
  *
  * Hook that integrates the existing WalletProvider with the new MultiWalletProvider.
- * 
- * This hook provides a unified interface for:
- * - Connecting to external wallets (MetaMask, Phantom, etc.)
- * - Managing multiple wallets per user
- * - Switching between wallets
- * - Maintaining the primary embedded wallet
+ *
+ * Race-condition fix (issue #514):
+ *   connectMetaMask() / connectPhantom() / connectStellar() / importStellarKey()
+ *   on WalletProvider now return the connected address directly as part of their
+ *   promise result.  This hook reads the returned address instead of reading
+ *   wallet.address from React context (which may still be null at the point of
+ *   reading because the context re-render hasn't happened yet).
+ *
+ *   If — for any reason — the provider returns null/undefined (older provider
+ *   build, edge-case error path) the hook falls back to a short poll of the
+ *   context state, retrying up to MAX_POLL_ATTEMPTS times with POLL_INTERVAL_MS
+ *   between each attempt.
  */
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useWallet } from "@/components/WalletProvider";
 import { useMultiWallet } from "@/components/MultiWalletProvider";
 import { useAuth } from "@/components/AuthProvider";
 import { MultiWalletRecord, WalletProviderType } from "@/app/lib/multiWalletStorage";
 import { migrateToMultiWallet } from "@/components/MultiWalletProvider";
 
+const POLL_INTERVAL_MS = 50;
+const MAX_POLL_ATTEMPTS = 20; // 1 second total
+
+/**
+ * Poll wallet.address from context until it is non-null or we time out.
+ * Used as a fallback when the connect method doesn't return the address.
+ */
+function pollAddress(
+  getAddress: () => string | null,
+  intervalMs: number,
+  maxAttempts: number
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    let attempts = 0;
+    const id = setInterval(() => {
+      const address = getAddress();
+      if (address) {
+        clearInterval(id);
+        resolve(address);
+        return;
+      }
+      attempts++;
+      if (attempts >= maxAttempts) {
+        clearInterval(id);
+        resolve(null);
+      }
+    }, intervalMs);
+  });
+}
+
 export function useMultiWalletConnection() {
   const { user } = useAuth();
   const wallet = useWallet();
   const multiWallet = useMultiWallet();
 
+  // Keep a ref to wallet.address so pollAddress can read the latest value
+  // without capturing a stale closure.
+  const addressRef = useRef<string | null>(wallet.address);
+  useEffect(() => {
+    addressRef.current = wallet.address;
+  }, [wallet.address]);
+
+  /**
+   * Resolve the address from a connect call.
+   * Prefers the value returned by the connect promise; falls back to polling.
+   */
+  const resolveAddress = useCallback(
+    async (returnedAddress: string | null | undefined): Promise<string | null> => {
+      if (returnedAddress) return returnedAddress;
+      // Fallback: poll context state
+      return pollAddress(() => addressRef.current, POLL_INTERVAL_MS, MAX_POLL_ATTEMPTS);
+    },
+    []
+  );
+
   // Migrate existing single-wallet to multi-wallet on first load
   useEffect(() => {
     if (user?.id && wallet.isConnected && wallet.address && wallet.walletType) {
       const existingWallets = multiWallet.wallets;
-      
-      // Only migrate if no wallets exist yet
       if (existingWallets.length === 0) {
         migrateToMultiWallet(user.id, {
           publicKey: wallet.address,
-          secretKey: wallet.stellarSecret || undefined,
+          secretKey: wallet.stellarSecret ?? undefined,
           walletType: wallet.walletType as WalletProviderType,
           network: wallet.chainId === "stellar" ? "testnet" : undefined,
-          chainId: wallet.chainId || undefined,
+          chainId: wallet.chainId ?? undefined,
         });
       }
     }
   }, [user?.id, wallet.isConnected, wallet.address, wallet.walletType, multiWallet.wallets]);
 
-  /**
-   * Connect to MetaMask and add to multi-wallet list
-   */
+  /** Connect to MetaMask and add to multi-wallet list */
   const connectMetaMask = useCallback(async () => {
-    await wallet.connectMetaMask();
-    
-    if (user?.id && wallet.address) {
+    const returned = await wallet.connectMetaMask();
+    const address = await resolveAddress(returned);
+
+    if (user?.id && address) {
       try {
         await multiWallet.addWallet({
-          publicKey: wallet.address,
+          publicKey: address,
           walletType: "metamask",
-          chainId: wallet.chainId || undefined,
+          chainId: wallet.chainId ?? undefined,
           isPrimary: false,
           isActive: true,
           label: "MetaMask",
@@ -60,18 +113,17 @@ export function useMultiWalletConnection() {
         console.error("Failed to add MetaMask to multi-wallet list:", err);
       }
     }
-  }, [wallet, user?.id, multiWallet]);
+  }, [wallet, user?.id, multiWallet, resolveAddress]);
 
-  /**
-   * Connect to Phantom and add to multi-wallet list
-   */
+  /** Connect to Phantom and add to multi-wallet list */
   const connectPhantom = useCallback(async () => {
-    await wallet.connectPhantom();
-    
-    if (user?.id && wallet.address) {
+    const returned = await wallet.connectPhantom();
+    const address = await resolveAddress(returned);
+
+    if (user?.id && address) {
       try {
         await multiWallet.addWallet({
-          publicKey: wallet.address,
+          publicKey: address,
           walletType: "phantom",
           chainId: "5EJ9Vc47M3VvM2x6wCk3F2nZ3qG7yB9rD6aX8cE5fG1h",
           isPrimary: false,
@@ -82,18 +134,17 @@ export function useMultiWalletConnection() {
         console.error("Failed to add Phantom to multi-wallet list:", err);
       }
     }
-  }, [wallet, user?.id, multiWallet]);
+  }, [wallet, user?.id, multiWallet, resolveAddress]);
 
-  /**
-   * Connect to Stellar and add to multi-wallet list
-   */
+  /** Connect to Stellar and add to multi-wallet list */
   const connectStellar = useCallback(async () => {
-    await wallet.connectStellar();
-    
-    if (user?.id && wallet.address) {
+    const returned = await wallet.connectStellar();
+    const address = await resolveAddress(returned);
+
+    if (user?.id && address) {
       try {
         await multiWallet.addWallet({
-          publicKey: wallet.address,
+          publicKey: address,
           walletType: "stellar",
           network: "testnet",
           isPrimary: false,
@@ -105,18 +156,17 @@ export function useMultiWalletConnection() {
         console.error("Failed to add Stellar to multi-wallet list:", err);
       }
     }
-  }, [wallet, user?.id, multiWallet]);
+  }, [wallet, user?.id, multiWallet, resolveAddress]);
 
-  /**
-   * Import existing Stellar key and add to multi-wallet list
-   */
+  /** Import existing Stellar key and add to multi-wallet list */
   const importStellarKey = useCallback(async (secret: string) => {
-    await wallet.importStellarKey(secret);
-    
-    if (user?.id && wallet.address) {
+    const returned = await wallet.importStellarKey(secret);
+    const address = await resolveAddress(returned);
+
+    if (user?.id && address) {
       try {
         await multiWallet.addWallet({
-          publicKey: wallet.address,
+          publicKey: address,
           walletType: "imported",
           network: "testnet",
           isPrimary: false,
@@ -128,22 +178,16 @@ export function useMultiWalletConnection() {
         console.error("Failed to add imported wallet to multi-wallet list:", err);
       }
     }
-  }, [wallet, user?.id, multiWallet]);
+  }, [wallet, user?.id, multiWallet, resolveAddress]);
 
-  /**
-   * Switch to a different wallet from the multi-wallet list
-   */
+  /** Switch to a different wallet from the multi-wallet list */
   const switchWallet = useCallback(
     async (walletId: string) => {
       const targetWallet = multiWallet.wallets.find((w) => w.id === walletId);
-      if (!targetWallet) {
-        throw new Error("Wallet not found");
-      }
+      if (!targetWallet) throw new Error("Wallet not found");
 
-      // Update multi-wallet active state
       multiWallet.switchWallet(walletId);
 
-      // Reconnect to the wallet using the appropriate method
       switch (targetWallet.walletType) {
         case "metamask":
           await wallet.connectMetaMask();
@@ -155,8 +199,7 @@ export function useMultiWalletConnection() {
         case "embedded":
         case "imported":
           if (targetWallet._encodedSecret) {
-            const secret = atob(targetWallet._encodedSecret);
-            await wallet.importStellarKey(secret);
+            await wallet.importStellarKey(atob(targetWallet._encodedSecret));
           } else {
             await wallet.connectStellar();
           }
@@ -168,25 +211,18 @@ export function useMultiWalletConnection() {
     [multiWallet, wallet]
   );
 
-  /**
-   * Disconnect the current wallet
-   */
+  /** Disconnect the current wallet */
   const disconnect = useCallback(() => {
     wallet.disconnect();
   }, [wallet]);
 
-  /**
-   * Remove a wallet from the multi-wallet list
-   */
+  /** Remove a wallet from the multi-wallet list */
   const removeWallet = useCallback(
     (walletId: string) => {
       const targetWallet = multiWallet.wallets.find((w) => w.id === walletId);
-      
-      // If removing the currently connected wallet, disconnect it
       if (targetWallet?.publicKey === wallet.address) {
         wallet.disconnect();
       }
-      
       multiWallet.removeWallet(walletId);
     },
     [multiWallet, wallet]
@@ -195,12 +231,12 @@ export function useMultiWalletConnection() {
   return {
     // Existing wallet state
     ...wallet,
-    
+
     // Multi-wallet state
     wallets: multiWallet.wallets,
     activeWallet: multiWallet.activeWallet,
     primaryWallet: multiWallet.primaryWallet,
-    
+
     // Multi-wallet operations
     connectMetaMask,
     connectPhantom,
@@ -210,7 +246,7 @@ export function useMultiWalletConnection() {
     removeWallet,
     setPrimaryWallet: multiWallet.setPrimaryWallet,
     updateWallet: multiWallet.updateWallet,
-    
+
     // Error handling
     isOperating: multiWallet.isOperating,
     multiWalletError: multiWallet.error,

--- a/app/hooks/useProcessStore.ts
+++ b/app/hooks/useProcessStore.ts
@@ -4,23 +4,24 @@
  * useProcessStore — compatibility re-export.
  *
  * The store has moved to app/store/processStore.ts (Zustand + persist).
- * This file keeps the old import path working so existing consumers
- * (ProcessDashboard, create/page.tsx) need zero changes.
- *
- * The returned shape is identical to the old hook:
- *   { process, update, startProcess, resetProcess }
+ * This file keeps the old import path working so existing consumers need zero changes.
  */
 
-import { useProcessStore as _useProcessStore, selectProcess, type ProcessState, type ProcessActions } from "@/app/store";
+import {
+  useProcessStore as _useProcessStore,
+  selectProcess,
+  selectHasHydrated,
+} from "@/app/store";
+import type { ProcessState, ProcessActions } from "@/app/store";
 
-// Re-export types so existing imports from this file keep working
 export type { ProcessStatus, ProcessState } from "@/app/store";
 
 export function useProcessStore() {
   const process = _useProcessStore(selectProcess);
+  const hasHydrated = _useProcessStore(selectHasHydrated);
   const update = _useProcessStore((s: ProcessState & ProcessActions) => s.update);
   const startProcess = _useProcessStore((s: ProcessState & ProcessActions) => s.startProcess);
   const resetProcess = _useProcessStore((s: ProcessState & ProcessActions) => s.resetProcess);
 
-  return { process, update, startProcess, resetProcess };
+  return { process, hasHydrated, update, startProcess, resetProcess };
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import AnalyticsProvider from "@/components/AnalyticsProvider";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ["latin", "latin-ext"], display: "swap" });
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://clipcash.ai"),

--- a/app/lib/mockApi.ts
+++ b/app/lib/mockApi.ts
@@ -214,10 +214,10 @@ export const saveOnboarding = rateLimiter(async (userId: string, step: number, d
   return { success: true, user };
 }, 10, 10000);
 
-export const getEarningsReport = rateLimiter(async (userId: string) => {
+export const getEarningsReport = rateLimiter(async (userId: string, { page = 1, pageSize = 20 }: { page?: number; pageSize?: number } = {}) => {
   await delay(1000 + Math.random() * 500);
 
-  const transactions: Transaction[] = [];
+  const allTransactions: Transaction[] = [];
   const platforms = ['YouTube', 'TikTok', 'Instagram', 'Twitch'] as const;
   const types = ['payout', 'royalty', 'mint', 'referral'] as const;
   const cryptoCurrencies = ['ETH', 'SOL', 'USDC'] as const;
@@ -246,17 +246,24 @@ export const getEarningsReport = rateLimiter(async (userId: string) => {
       taxId: `TAX-${String(i + 1).padStart(3, '0')}`,
     };
 
-    transactions.push(tx);
+    allTransactions.push(tx);
     totalAmount += tx.amount;
   }
+
+  const total = allTransactions.length;
+  const totalPages = Math.ceil(total / pageSize);
+  const safePage = Math.max(1, Math.min(page, totalPages || 1));
+  const start = (safePage - 1) * pageSize;
+  const transactions = allTransactions.slice(start, start + pageSize);
 
   return {
     transactions,
     summary: {
       total: totalAmount.toFixed(2),
-      completed: transactions.filter(t => t.status === 'completed').reduce((sum, t) => sum + t.amount, 0).toFixed(2),
-      pending: transactions.filter(t => t.status === 'pending').reduce((sum, t) => sum + t.amount, 0).toFixed(2),
-    }
+      completed: allTransactions.filter(t => t.status === 'completed').reduce((sum, t) => sum + t.amount, 0).toFixed(2),
+      pending: allTransactions.filter(t => t.status === 'pending').reduce((sum, t) => sum + t.amount, 0).toFixed(2),
+    },
+    pagination: { page: safePage, pageSize, total, totalPages },
   };
 }, 10, 10000);
 

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -33,6 +33,7 @@ export {
   selectProcess,
   selectProcessStatus,
   selectProcessProgress,
+  selectHasHydrated,
   defaultProcessState,
 } from "./processStore";
 

--- a/app/store/processStore.test.ts
+++ b/app/store/processStore.test.ts
@@ -1,9 +1,20 @@
 import { act, renderHook } from '@testing-library/react';
-import { useProcessStore, defaultProcessState, selectProcess, selectProcessStatus, selectProcessProgress } from './processStore';
+import { useProcessStore, defaultProcessState, selectProcess, selectProcessStatus, selectProcessProgress, selectHasHydrated } from './processStore';
+
+// Mock secureStorage so tests run without real crypto
+jest.mock('@/app/lib/secureStorage', () => ({
+  secureStorage: {
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined),
+  },
+}));
 
 describe('processStore', () => {
   beforeEach(() => {
-    useProcessStore.setState(defaultProcessState);
+    // Reset to default state (but preserve persist API by patching only state fields)
+    useProcessStore.setState({ ...defaultProcessState });
+    jest.clearAllMocks();
   });
 
   it('has correct initial state', () => {
@@ -41,7 +52,7 @@ describe('processStore', () => {
 
   it('update works with function patch', () => {
     const { result } = renderHook(() => useProcessStore());
-    
+
     useProcessStore.setState({ momentsFound: 2 });
 
     act(() => {
@@ -51,13 +62,15 @@ describe('processStore', () => {
     expect(result.current.momentsFound).toBe(3);
   });
 
-  it('resetProcess restores default state', () => {
+  it('resetProcess restores default state and keeps hasHydrated=true', () => {
     const { result } = renderHook(() => useProcessStore());
+
+    useProcessStore.setState({ hasHydrated: true });
 
     act(() => {
       result.current.startProcess('test', 'test label');
     });
-    
+
     expect(result.current.id).toBe('test');
 
     act(() => {
@@ -67,6 +80,8 @@ describe('processStore', () => {
     expect(result.current.id).toBe(defaultProcessState.id);
     expect(result.current.label).toBe(defaultProcessState.label);
     expect(result.current.status).toBe(defaultProcessState.status);
+    // After reset hasHydrated stays true — store is already hydrated
+    expect(result.current.hasHydrated).toBe(true);
   });
 
   it('selectors return correct values', () => {
@@ -79,6 +94,7 @@ describe('processStore', () => {
       completedAt: null,
       momentsFound: 5,
       estimatedSecondsRemaining: 10,
+      hasHydrated: true,
     });
 
     const state = useProcessStore.getState();
@@ -92,9 +108,81 @@ describe('processStore', () => {
       completedAt: null,
       momentsFound: 5,
       estimatedSecondsRemaining: 10,
+      hasHydrated: true,
     });
 
     expect(selectProcessStatus(state)).toBe('processing');
     expect(selectProcessProgress(state)).toBe(75);
+    expect(selectHasHydrated(state)).toBe(true);
+  });
+});
+
+// ─── hasHydrated lifecycle ────────────────────────────────────────────────────
+
+describe('processStore — hasHydrated lifecycle (issue #520)', () => {
+  const { secureStorage } = require('@/app/lib/secureStorage');
+
+  beforeEach(() => {
+    useProcessStore.setState({ ...defaultProcessState });
+    jest.clearAllMocks();
+  });
+
+  it('starts with hasHydrated = false', () => {
+    // defaultProcessState has hasHydrated: false
+    expect(useProcessStore.getState().hasHydrated).toBe(false);
+    expect(selectHasHydrated(useProcessStore.getState())).toBe(false);
+  });
+
+  it('becomes true after async rehydration resolves', async () => {
+    const storedState = {
+      state: { id: 'restored', label: 'Restored', progress: 42, status: 'processing',
+                startedAt: 1000, completedAt: null, momentsFound: 3, estimatedSecondsRemaining: 60 },
+      version: 0,
+    };
+    secureStorage.getItem.mockResolvedValue(JSON.stringify(storedState));
+
+    // Reset hasHydrated to false before rehydrating
+    useProcessStore.setState({ hasHydrated: false });
+    expect(useProcessStore.getState().hasHydrated).toBe(false);
+
+    // Trigger rehydration and wait for the async getItem to resolve
+    await act(async () => {
+      await useProcessStore.persist.rehydrate();
+    });
+
+    expect(useProcessStore.getState().hasHydrated).toBe(true);
+  });
+
+  it('becomes true even when storage returns null (no persisted data)', async () => {
+    secureStorage.getItem.mockResolvedValue(null);
+
+    useProcessStore.setState({ hasHydrated: false });
+
+    await act(async () => {
+      await useProcessStore.persist.rehydrate();
+    });
+
+    expect(useProcessStore.getState().hasHydrated).toBe(true);
+  });
+
+  it('restores persisted state alongside setting hasHydrated', async () => {
+    const storedState = {
+      state: { id: 'job_abc', label: 'My Video', progress: 55, status: 'processing',
+                startedAt: 500, completedAt: null, momentsFound: 7, estimatedSecondsRemaining: 30 },
+      version: 0,
+    };
+    secureStorage.getItem.mockResolvedValue(JSON.stringify(storedState));
+
+    useProcessStore.setState({ ...defaultProcessState });
+
+    await act(async () => {
+      await useProcessStore.persist.rehydrate();
+    });
+
+    const state = useProcessStore.getState();
+    expect(state.hasHydrated).toBe(true);
+    expect(state.id).toBe('job_abc');
+    expect(state.progress).toBe(55);
+    expect(state.momentsFound).toBe(7);
   });
 });

--- a/app/store/processStore.ts
+++ b/app/store/processStore.ts
@@ -1,14 +1,11 @@
 "use client";
 
 /**
- * Process Zustand store (with localStorage persistence)
+ * Process Zustand store (with secureStorage persistence)
  *
- * Replaces the manual localStorage read/write in the old useProcessStore hook.
- * Zustand's `persist` middleware handles hydration and serialisation automatically,
- * so components no longer need to worry about SSR/hydration mismatches.
- *
- * Public API is intentionally identical to the old hook so existing call-sites
- * (ProcessDashboard, create/page.tsx) need zero changes.
+ * secureStorage is fully async (AES-GCM), so we use skipHydration: true and
+ * manually call rehydrate() after the async getItem resolves. A hasHydrated
+ * flag lets components show a loading state until the store is ready.
  */
 
 import { create } from "zustand";
@@ -27,6 +24,7 @@ export const defaultProcessState: ProcessState = {
   completedAt: null,
   momentsFound: 0,
   estimatedSecondsRemaining: null,
+  hasHydrated: false,
 };
 
 // ─── Store ────────────────────────────────────────────────────────────────────
@@ -62,21 +60,20 @@ export const useProcessStore = create<ProcessState & ProcessActions>()(
       },
 
       resetProcess: () => {
-        set(defaultProcessState);
+        set({ ...defaultProcessState, hasHydrated: true });
       },
     }),
     {
-      name: "clips_process_state", // same localStorage key as before
+      name: "clips_process_state",
       storage: createJSONStorage(() =>
         typeof window !== "undefined"
           ? secureStorage
           : {
-              getItem: async (name: string) => null,
-              setItem: async (name: string, value: string) => {},
-              removeItem: async (name: string) => {},
+              getItem: async (_name: string) => null,
+              setItem: async (_name: string, _value: string) => {},
+              removeItem: async (_name: string) => {},
             }
       ),
-      // Only persist the state fields, not the action functions
       partialize: (state) => ({
         id: state.id,
         label: state.label,
@@ -86,14 +83,30 @@ export const useProcessStore = create<ProcessState & ProcessActions>()(
         completedAt: state.completedAt,
         momentsFound: state.momentsFound,
         estimatedSecondsRemaining: state.estimatedSecondsRemaining,
+        // hasHydrated is runtime-only — never persisted
       }),
+      // Skip automatic synchronous hydration; we drive it manually below
+      // so the async decrypt has time to resolve before state is applied.
+      skipHydration: true,
+      onRehydrateStorage: () => (_state, error) => {
+        if (!error) {
+          useProcessStore.setState({ hasHydrated: true });
+        }
+      },
     }
   )
 );
 
+// Trigger rehydration on the client. This is called once the module is
+// imported in a browser context; the persist middleware will await
+// secureStorage.getItem and then apply the stored state, after which
+// onRehydrateStorage fires and sets hasHydrated = true.
+if (typeof window !== "undefined") {
+  useProcessStore.persist.rehydrate();
+}
+
 // ─── Selectors ────────────────────────────────────────────────────────────────
 
-/** Select the process state object (matches old hook's `process` return value) */
 export const selectProcess = (
   s: ProcessState & ProcessActions
 ): ProcessState => ({
@@ -105,12 +118,14 @@ export const selectProcess = (
   completedAt: s.completedAt,
   momentsFound: s.momentsFound,
   estimatedSecondsRemaining: s.estimatedSecondsRemaining,
+  hasHydrated: s.hasHydrated,
 });
 
-/** Select only the status — cheap subscription for status-only consumers */
 export const selectProcessStatus = (s: ProcessState & ProcessActions) =>
   s.status;
 
-/** Select only the progress value */
 export const selectProcessProgress = (s: ProcessState & ProcessActions) =>
   s.progress;
+
+export const selectHasHydrated = (s: ProcessState & ProcessActions) =>
+  s.hasHydrated;

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -73,6 +73,8 @@ export interface ProcessState {
   completedAt: number | null;
   momentsFound: number;
   estimatedSecondsRemaining: number | null;
+  /** True once the async secureStorage rehydration has resolved */
+  hasHydrated: boolean;
 }
 
 export interface ProcessActions {

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { useSession, signOut } from "next-auth/react";
+import { useRouter, usePathname } from "next/navigation";
+
+const STORAGE_KEY = "clipcash_user";
+
+const PUBLIC_ROUTES = ["/", "/login", "/privacy", "/terms", "/status", "/cookies"];
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name?: string;
+  onboardingStep?: number;
+  avatarUrl?: string;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isLoading: boolean;
+  setUser: (user: AuthUser) => void;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [user, setUserState] = useState<AuthUser | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? (JSON.parse(raw) as AuthUser) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const isLoading = status === "loading";
+
+  // Sync NextAuth session -> local state
+  useEffect(() => {
+    if (status === "loading") return;
+
+    if (status === "authenticated" && session?.user) {
+      const { email, name } = session.user as { email?: string; name?: string; onboardingStep?: number };
+      const sessionUser: AuthUser = {
+        id: email ?? "oauth_user",
+        email: email ?? "",
+        name: name ?? undefined,
+        onboardingStep: (session.user as any).onboardingStep,
+      };
+      setUserState(sessionUser);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(sessionUser));
+    } else if (status === "unauthenticated") {
+      // Only clear if we were previously synced from a session (not a manual mock login)
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        try {
+          const stored = JSON.parse(raw) as AuthUser;
+          // If the stored user looks like it came from oauth (no explicit setUser call),
+          // treat session expiry as a logout.
+          if (!stored.id.startsWith("mock")) {
+            localStorage.removeItem(STORAGE_KEY);
+            setUserState(null);
+            signOut({ redirect: false });
+          }
+        } catch {
+          localStorage.removeItem(STORAGE_KEY);
+          setUserState(null);
+        }
+      }
+    }
+  }, [status, session]);
+
+  // Route guard — only redirect when we know for certain the user is not authenticated
+  useEffect(() => {
+    if (isLoading) return;
+    if (status === "authenticated") return; // session sync hasn't flushed to user state yet
+    const isPublic = PUBLIC_ROUTES.some(
+      (r) => pathname === r || pathname.startsWith(r + "/")
+    );
+    if (!user && !isPublic) {
+      router.push("/login");
+    }
+  }, [user, isLoading, status, pathname, router]);
+
+  const setUser = useCallback((newUser: AuthUser) => {
+    setUserState(newUser);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newUser));
+  }, []);
+
+  const logout = useCallback(async () => {
+    setUserState(null);
+    localStorage.removeItem(STORAGE_KEY);
+    await signOut({ redirect: false });
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, setUser, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
+  return ctx;
+}

--- a/components/MultiWalletProvider.tsx
+++ b/components/MultiWalletProvider.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import {
+  MultiWalletRecord,
+  MultiWalletStorage,
+  WalletProviderType,
+} from "@/app/lib/multiWalletStorage";
+import { useAuth } from "@/components/AuthProvider";
+
+// Analytics is optional — import lazily to avoid breaking tests that don't mock it
+let analytics: { trackEvent: (name: string, props?: Record<string, unknown>) => void } | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  analytics = require("@/lib/analytics").default;
+} catch {}
+
+interface MultiWalletContextValue {
+  wallets: MultiWalletRecord[];
+  activeWallet: MultiWalletRecord | null;
+  primaryWallet: MultiWalletRecord | null;
+  isOperating: boolean;
+  error: string | null;
+  addWallet: (
+    data: Omit<MultiWalletRecord, "id" | "userId" | "createdAt" | "lastUsedAt">
+  ) => Promise<MultiWalletRecord>;
+  removeWallet: (walletId: string) => void;
+  switchWallet: (walletId: string) => void;
+  setPrimaryWallet: (walletId: string) => void;
+  updateWallet: (walletId: string, updates: Partial<MultiWalletRecord>) => void;
+  refreshWallets: () => void;
+  clearError: () => void;
+}
+
+const MultiWalletContext = createContext<MultiWalletContextValue | null>(null);
+
+export function MultiWalletProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const [wallets, setWallets] = useState<MultiWalletRecord[]>([]);
+  const [isOperating, setIsOperating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadWallets = useCallback(() => {
+    if (!user?.id) {
+      setWallets([]);
+      return;
+    }
+    setWallets(MultiWalletStorage.getAll(user.id));
+  }, [user?.id]);
+
+  useEffect(() => {
+    loadWallets();
+  }, [loadWallets]);
+
+  const activeWallet = wallets.find((w) => w.isActive) ?? null;
+  const primaryWallet = wallets.find((w) => w.isPrimary) ?? null;
+
+  const addWallet = useCallback(
+    async (
+      data: Omit<MultiWalletRecord, "id" | "userId" | "createdAt" | "lastUsedAt">
+    ): Promise<MultiWalletRecord> => {
+      if (!user?.id) throw new Error("User not authenticated");
+      setIsOperating(true);
+      try {
+        const record = MultiWalletStorage.addWallet(user.id, data);
+        setWallets(MultiWalletStorage.getAll(user.id));
+        analytics?.trackEvent("wallet_added", { wallet_type: data.walletType });
+        return record;
+      } catch (err: any) {
+        const msg = err?.message ?? "Failed to add wallet";
+        setError(msg);
+        throw err;
+      } finally {
+        setIsOperating(false);
+      }
+    },
+    [user?.id]
+  );
+
+  const removeWallet = useCallback(
+    (walletId: string) => {
+      if (!user?.id) return;
+      const target = wallets.find((w) => w.id === walletId);
+      if (target?.isPrimary) {
+        setError("Cannot remove primary wallet");
+        return;
+      }
+      MultiWalletStorage.removeWallet(user.id, walletId);
+      setWallets(MultiWalletStorage.getAll(user.id));
+    },
+    [user?.id, wallets]
+  );
+
+  const switchWallet = useCallback(
+    (walletId: string) => {
+      if (!user?.id) return;
+      MultiWalletStorage.setActiveWallet(user.id, walletId);
+      setWallets(MultiWalletStorage.getAll(user.id));
+      analytics?.trackEvent("wallet_switched", { wallet_id: walletId });
+    },
+    [user?.id]
+  );
+
+  const setPrimaryWallet = useCallback(
+    (walletId: string) => {
+      if (!user?.id) return;
+      MultiWalletStorage.updateWallet(user.id, walletId, { isPrimary: true });
+      setWallets(MultiWalletStorage.getAll(user.id));
+    },
+    [user?.id]
+  );
+
+  const updateWallet = useCallback(
+    (walletId: string, updates: Partial<MultiWalletRecord>) => {
+      if (!user?.id) return;
+      MultiWalletStorage.updateWallet(user.id, walletId, updates);
+      setWallets(MultiWalletStorage.getAll(user.id));
+    },
+    [user?.id]
+  );
+
+  const refreshWallets = useCallback(() => {
+    loadWallets();
+  }, [loadWallets]);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return (
+    <MultiWalletContext.Provider
+      value={{
+        wallets,
+        activeWallet,
+        primaryWallet,
+        isOperating,
+        error,
+        addWallet,
+        removeWallet,
+        switchWallet,
+        setPrimaryWallet,
+        updateWallet,
+        refreshWallets,
+        clearError,
+      }}
+    >
+      {children}
+    </MultiWalletContext.Provider>
+  );
+}
+
+export function useMultiWallet(): MultiWalletContextValue {
+  const ctx = useContext(MultiWalletContext);
+  if (!ctx) throw new Error("useMultiWallet must be used inside <MultiWalletProvider>");
+  return ctx;
+}
+
+/**
+ * One-time migration from single-wallet to multi-wallet storage.
+ * No-op if the user already has wallets.
+ */
+export function migrateToMultiWallet(
+  userId: string,
+  data: {
+    publicKey: string;
+    secretKey?: string;
+    walletType: WalletProviderType;
+    network?: "testnet" | "mainnet";
+    chainId?: string;
+  }
+): void {
+  MultiWalletStorage.migrateFromSingleWallet(userId, data);
+}

--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { secureStorage } from "@/app/lib/secureStorage";
+
+const STORAGE_KEY = "clipcash_wallet";
+
+export type WalletType = "metamask" | "phantom" | "stellar" | "embedded" | "imported";
+
+interface WalletState {
+  address: string | null;
+  chainId: string | null;
+  walletType: WalletType | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: string | null;
+  stellarSecret: string | null;
+}
+
+interface WalletContextValue extends WalletState {
+  connectMetaMask: () => Promise<string | null>;
+  connectPhantom: () => Promise<string | null>;
+  connectStellar: () => Promise<string | null>;
+  importStellarKey: (secret: string) => Promise<string | null>;
+  disconnect: () => void;
+  clearError: () => void;
+}
+
+const WalletContext = createContext<WalletContextValue | null>(null);
+
+const DEFAULT_STATE: WalletState = {
+  address: null,
+  chainId: null,
+  walletType: null,
+  isConnected: false,
+  isConnecting: false,
+  error: null,
+  stellarSecret: null,
+};
+
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<WalletState>(DEFAULT_STATE);
+
+  // Restore persisted session on mount
+  useEffect(() => {
+    secureStorage.getItem(STORAGE_KEY).then((raw) => {
+      if (!raw) return;
+      try {
+        const data = JSON.parse(raw as string);
+        setState((prev) => ({
+          ...prev,
+          address: data.address ?? null,
+          chainId: data.chainId ?? null,
+          walletType: data.walletType ?? null,
+          isConnected: !!data.address,
+        }));
+      } catch {
+        // Malformed — ignore
+      }
+    });
+  }, []);
+
+  // Register MetaMask event listeners
+  useEffect(() => {
+    const eth = (window as any).ethereum;
+    if (!eth) return;
+
+    const onAccounts = (accounts: string[]) => {
+      if (accounts.length === 0) {
+        setState(DEFAULT_STATE);
+        secureStorage.removeItem(STORAGE_KEY);
+      } else {
+        setState((prev) => ({ ...prev, address: accounts[0] }));
+      }
+    };
+    const onChain = (chainId: string) => {
+      setState((prev) => ({ ...prev, chainId }));
+    };
+
+    eth.on("accountsChanged", onAccounts);
+    eth.on("chainChanged", onChain);
+    return () => {
+      eth.removeListener("accountsChanged", onAccounts);
+      eth.removeListener("chainChanged", onChain);
+    };
+  }, []);
+
+  // Register Phantom event listeners
+  useEffect(() => {
+    const sol = (window as any).solana;
+    if (!sol) return;
+
+    const onConnect = (publicKey: { toBase58: () => string }) => {
+      const address = publicKey.toBase58();
+      setState((prev) => ({ ...prev, address, isConnected: true, walletType: "phantom" }));
+    };
+    const onAccountChanged = (publicKey: { toBase58: () => string } | null) => {
+      if (!publicKey) {
+        setState(DEFAULT_STATE);
+        secureStorage.removeItem(STORAGE_KEY);
+      } else {
+        setState((prev) => ({ ...prev, address: publicKey.toBase58() }));
+      }
+    };
+
+    sol.on("connect", onConnect);
+    sol.on("accountChanged", onAccountChanged);
+    return () => {
+      sol.removeListener("connect", onConnect);
+      sol.removeListener("accountChanged", onAccountChanged);
+    };
+  }, []);
+
+  const persist = useCallback(
+    (address: string, chainId: string | null, walletType: WalletType) => {
+      secureStorage.setItem(STORAGE_KEY, JSON.stringify({ address, chainId, walletType }));
+    },
+    []
+  );
+
+  const connectMetaMask = useCallback(async (): Promise<string | null> => {
+    const eth = (window as any).ethereum;
+    if (!eth) {
+      setState((prev) => ({ ...prev, error: "MetaMask is not installed" }));
+      return null;
+    }
+
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+    try {
+      const accounts: string[] = await eth.request({ method: "eth_requestAccounts" });
+      if (!accounts || accounts.length === 0) {
+        setState((prev) => ({ ...prev, isConnecting: false, error: "No accounts returned" }));
+        return null;
+      }
+      const address = accounts[0];
+      let chainId: string | null = null;
+      try {
+        chainId = await eth.request({ method: "eth_chainId" });
+      } catch {}
+
+      setState({
+        address,
+        chainId,
+        walletType: "metamask",
+        isConnected: true,
+        isConnecting: false,
+        error: null,
+        stellarSecret: null,
+      });
+      persist(address, chainId, "metamask");
+      return address;
+    } catch (err: any) {
+      const msg = err?.code === 4001 ? "Connection rejected by user" : (err?.message ?? "Connection failed");
+      setState((prev) => ({ ...prev, isConnecting: false, isConnected: false, error: msg }));
+      return null;
+    }
+  }, [persist]);
+
+  const connectPhantom = useCallback(async (): Promise<string | null> => {
+    const sol = (window as any).solana;
+    if (!sol?.isPhantom) {
+      setState((prev) => ({ ...prev, error: "Phantom wallet not detected" }));
+      return null;
+    }
+
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+    try {
+      const resp = await sol.connect();
+      const address: string = resp.publicKey.toBase58();
+
+      setState({
+        address,
+        chainId: null,
+        walletType: "phantom",
+        isConnected: true,
+        isConnecting: false,
+        error: null,
+        stellarSecret: null,
+      });
+      persist(address, null, "phantom");
+      return address;
+    } catch (err: any) {
+      const msg = err?.code === 4001 ? "Connection rejected by user" : (err?.message ?? "Connection failed");
+      setState((prev) => ({ ...prev, isConnecting: false, isConnected: false, error: msg }));
+      return null;
+    }
+  }, [persist]);
+
+  const connectStellar = useCallback(async (): Promise<string | null> => {
+    // Stellar connection via Freighter or similar is handled externally;
+    // this placeholder returns null. Real implementations can override via extension.
+    setState((prev) => ({ ...prev, error: "Stellar connection not configured" }));
+    return null;
+  }, []);
+
+  const importStellarKey = useCallback(async (secret: string): Promise<string | null> => {
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+    try {
+      // Derive address from secret key using Stellar SDK if available,
+      // otherwise return the secret as a placeholder (real implementation resolves this via the SDK).
+      const { Keypair } = await import("@stellar/stellar-sdk");
+      const keypair = Keypair.fromSecret(secret);
+      const address = keypair.publicKey();
+
+      setState({
+        address,
+        chainId: "stellar",
+        walletType: "imported",
+        isConnected: true,
+        isConnecting: false,
+        error: null,
+        stellarSecret: secret,
+      });
+      persist(address, "stellar", "imported");
+      return address;
+    } catch (err: any) {
+      setState((prev) => ({
+        ...prev,
+        isConnecting: false,
+        error: err?.message ?? "Failed to import Stellar key",
+      }));
+      return null;
+    }
+  }, [persist]);
+
+  const disconnect = useCallback(() => {
+    const sol = (window as any).solana;
+    if (sol && state.walletType === "phantom") {
+      try { sol.disconnect(); } catch {}
+    }
+    setState(DEFAULT_STATE);
+    secureStorage.removeItem(STORAGE_KEY);
+  }, [state.walletType]);
+
+  const clearError = useCallback(() => {
+    setState((prev) => ({ ...prev, error: null }));
+  }, []);
+
+  return (
+    <WalletContext.Provider
+      value={{
+        ...state,
+        connectMetaMask,
+        connectPhantom,
+        connectStellar,
+        importStellarKey,
+        disconnect,
+        clearError,
+      }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet(): WalletContextValue {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used inside <WalletProvider>");
+  return ctx;
+}
+
+export function truncateAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}

--- a/components/dashboard/EarningsLayout.tsx
+++ b/components/dashboard/EarningsLayout.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import React from "react";
+import DashboardHeader from "@/app/components/DashboardHeader";
+
+export default function EarningsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background text-white font-sans">
+      <DashboardHeader />
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-10 py-10">{children}</main>
+    </div>
+  );
+}

--- a/components/dashboard/EarningsTable.tsx
+++ b/components/dashboard/EarningsTable.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React, { useEffect, useMemo } from "react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { useFilterQueryState } from "@/hooks/useFilterQueryState";
+import type { Transaction, Summary } from "@/app/lib/mockApi";
+
+interface EarningsTableProps {
+  transactions: Transaction[];
+  summary: Summary;
+  loading?: boolean;
+  onFilteredTransactionsChange?: (filtered: Transaction[]) => void;
+  /** Pagination from the parent (server-driven). When provided, renders prev/next controls. */
+  pagination?: { page: number; pageSize: number; total: number; totalPages: number };
+  onPageChange?: (page: number) => void;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  completed: "text-green-400",
+  pending: "text-yellow-400",
+  failed: "text-red-400",
+};
+
+export default function EarningsTable({
+  transactions,
+  summary,
+  loading = false,
+  onFilteredTransactionsChange,
+  pagination,
+  onPageChange,
+}: EarningsTableProps) {
+  const { filters, updateFilters, resetFilters } = useFilterQueryState({
+    search: "",
+    startDate: "",
+    endDate: "",
+  });
+
+  const { search, startDate, endDate } = filters;
+
+  const filtered = useMemo(() => {
+    return transactions.filter((tx) => {
+      if (search) {
+        const q = search.toLowerCase();
+        if (
+          !tx.description.toLowerCase().includes(q) &&
+          !tx.id.toLowerCase().includes(q) &&
+          !tx.platform.toLowerCase().includes(q)
+        ) {
+          return false;
+        }
+      }
+      if (startDate && tx.date < startDate) return false;
+      if (endDate && tx.date > endDate) return false;
+      return true;
+    });
+  }, [transactions, search, startDate, endDate]);
+
+  useEffect(() => {
+    onFilteredTransactionsChange?.(filtered);
+  }, [filtered, onFilteredTransactionsChange]);
+
+  const hasDates = startDate || endDate;
+
+  return (
+    <div className="rounded-2xl bg-surface border border-white/5 overflow-hidden">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-end gap-3 px-5 py-4 border-b border-white/5">
+        {/* Search */}
+        <div className="relative flex-1 min-w-[180px]">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => updateFilters({ search: e.target.value })}
+            placeholder="Search by ID, description or platform"
+            className="w-full bg-input text-white text-sm rounded-xl px-4 py-2.5 pr-8 border border-white/10 placeholder:text-muted-foreground focus:outline-none focus:border-brand/50"
+          />
+          {search && (
+            <button
+              onClick={() => updateFilters({ search: "" })}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-white"
+              aria-label="Clear search"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        {/* Date range */}
+        <div className="flex items-end gap-2">
+          <label className="flex flex-col gap-1 text-[11px] font-bold text-muted-foreground uppercase tracking-widest">
+            From
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => updateFilters({ startDate: e.target.value })}
+              className="bg-input text-white text-sm rounded-xl px-3 py-2 border border-white/10 focus:outline-none focus:border-brand/50"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-[11px] font-bold text-muted-foreground uppercase tracking-widest">
+            To
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => updateFilters({ endDate: e.target.value })}
+              className="bg-input text-white text-sm rounded-xl px-3 py-2 border border-white/10 focus:outline-none focus:border-brand/50"
+            />
+          </label>
+          {hasDates && (
+            <button
+              onClick={() => resetFilters()}
+              className="text-xs text-muted-foreground hover:text-white underline pb-2"
+            >
+              Clear dates
+            </button>
+          )}
+        </div>
+
+        {/* Count */}
+        <span className="ml-auto text-xs text-muted-foreground whitespace-nowrap">
+          {filtered.length} of {transactions.length} transactions
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-white/5 text-muted-foreground text-[11px] uppercase tracking-widest">
+              <th className="px-5 py-3 text-left">Date</th>
+              <th className="px-5 py-3 text-left">Description</th>
+              <th className="px-5 py-3 text-left">Platform</th>
+              <th className="px-5 py-3 text-right">Amount</th>
+              <th className="px-5 py-3 text-left">Status</th>
+              <th className="px-5 py-3 text-left">Tax ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 5 }).map((_, i) => (
+                <tr key={i} className="border-b border-white/5">
+                  {Array.from({ length: 6 }).map((_, j) => (
+                    <td key={j} className="px-5 py-3.5">
+                      <div className="h-4 rounded bg-white/6 animate-pulse" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : filtered.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-5 py-10 text-center text-muted-foreground">
+                  No transactions match your filters.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((tx) => (
+                <tr key={tx.id} className="border-b border-white/5 hover:bg-white/[0.02] transition-colors">
+                  <td className="px-5 py-3.5 text-muted-foreground">{tx.date}</td>
+                  <td className="px-5 py-3.5 text-white">{tx.description}</td>
+                  <td className="px-5 py-3.5 text-muted-foreground">{tx.platform}</td>
+                  <td className="px-5 py-3.5 text-right font-mono font-bold text-white">
+                    ${tx.amount.toFixed(2)}
+                    {tx.cryptoAmount && (
+                      <span className="block text-[11px] text-muted-foreground font-normal">
+                        {tx.cryptoAmount} {tx.cryptoCurrency}
+                      </span>
+                    )}
+                  </td>
+                  <td className={`px-5 py-3.5 font-semibold capitalize ${STATUS_STYLES[tx.status] ?? ""}`}>
+                    {tx.status}
+                  </td>
+                  <td className="px-5 py-3.5 text-muted-foreground font-mono text-[12px]">{tx.taxId}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination controls */}
+      {pagination && pagination.totalPages > 1 && onPageChange && (
+        <div className="flex items-center justify-between px-5 py-4 border-t border-white/5">
+          <button
+            onClick={() => onPageChange(pagination.page - 1)}
+            disabled={pagination.page <= 1}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-bold border border-white/10 bg-surface hover:bg-input disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Prev
+          </button>
+
+          <span className="text-sm text-muted-foreground">
+            Page{" "}
+            <span className="font-bold text-white">{pagination.page}</span>
+            {" "}of{" "}
+            <span className="font-bold text-white">{pagination.totalPages}</span>
+            <span className="ml-2 text-[12px]">({pagination.total} total)</span>
+          </span>
+
+          <button
+            onClick={() => onPageChange(pagination.page + 1)}
+            disabled={pagination.page >= pagination.totalPages}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-bold border border-white/10 bg-surface hover:bg-input disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Next
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/StatCard.tsx
+++ b/components/dashboard/StatCard.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from "react";
+import type { LucideIcon } from "lucide-react";
+import { TrendingUp } from "lucide-react";
+
+interface StatCardProps {
+  label: string;
+  value: string;
+  trend?: string;
+  icon?: LucideIcon;
+  hideTrendIcon?: boolean;
+}
+
+export default function StatCard({ label, value, trend, icon: Icon, hideTrendIcon }: StatCardProps) {
+  return (
+    <div className="bg-surface border border-white/5 rounded-2xl p-6 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-bold text-muted-foreground uppercase tracking-widest">{label}</span>
+        {Icon && <Icon className="w-4 h-4 text-muted-foreground" />}
+      </div>
+      <span className="text-2xl font-extrabold text-white">{value}</span>
+      {trend && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          {!hideTrendIcon && <TrendingUp className="w-3 h-3 text-green-400" />}
+          <span>{trend}</span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
closes #514 
closes #519 
closes #520 
closes #521 

## Summary

Resolves four issues in a single PR.

---

### #514 — Fix race condition in `useMultiWalletConnection`

**Problem:** After `await wallet.connectMetaMask()`, the hook immediately read `wallet.address` from React context. The context update happens on the next render, so the address was always `null` at that point.

**Fix:**
- `WalletProvider`: `connectMetaMask`, `connectPhantom`, `connectStellar`, `importStellarKey` now return `Promise<string | null>` with the connected address extracted directly from the provider response (before any re-render).
- `useMultiWalletConnection`: uses the returned address; falls back to polling context state (50 ms × 20 attempts) if the provider returns `null`.
- New components: `components/WalletProvider.tsx`, `MultiWalletProvider.tsx`, `AuthProvider.tsx`.
- **Tests:** 6 unit tests — address captured without second render cycle, polling fallback, `connectPhantom`, `importStellarKey`.

---

### #519 — Add `next/font` optimisation for all custom fonts

**Problem:** Inter loaded with `subsets: ['latin']` only, missing accented characters for `es`/`fr`/`pt` locales. No explicit `font-display` set.

**Fix** (one line in `app/layout.tsx`):
```ts
const inter = Inter({ subsets: ['latin', 'latin-ext'], display: 'swap' });
```
- `latin-ext` covers all accented glyphs used by the app's supported locales.
- `display: 'swap'` eliminates invisible-text flash that contributes to CLS.

---

### #520 — Fix `useProcessStore` with async `secureStorage` and Zustand persist

**Problem:** Zustand `persist` hydrated synchronously; `secureStorage.getItem` is async (AES-GCM), so initial state was always empty.

**Fix:**
- `skipHydration: true` + manual `rehydrate()` on client mount.
- `onRehydrateStorage` sets `hasHydrated = true` once decrypt resolves.
- Processing page shows a spinner until `hasHydrated` is true.
- **Tests:** 4 lifecycle tests.

---

### #521 — Add pagination to earnings table and clips grid

**Problem:** All 55 transactions returned and rendered at once.

**Fix:**
- `getEarningsReport`: accepts `{ page, pageSize }`, returns `pagination` metadata.
- `GET /api/earnings`: new route with `?page&pageSize`.
- `EarningsTable`: prev/next controls, search + date filters in URL params.
- `EarningsPage`: page/pageSize via `useFilterQueryState`.
- **Tests:** 9 boundary tests.