### PR TITLE
refactor: replace magic numbers with named constants across codebase

### DIFF
--- a/__tests__/api/jobs.csrf.test.ts
+++ b/__tests__/api/jobs.csrf.test.ts
@@ -7,6 +7,8 @@ import { NextRequest } from "next/server";
 import { POST as jobPOST } from "@/app/api/jobs/[id]/route";
 import { jobStore } from "@/app/api/jobs/shared/jobStore";
 
+import { JOB_ESTIMATED_SECONDS } from "@/app/lib/constants";
+
 jest.mock("next-auth", () => ({ default: jest.fn(), getServerSession: jest.fn() }));
 jest.mock("@/app/lib/aiBackend", () => ({
   dispatchJob: jest.fn().mockResolvedValue({ dispatched: true }),
@@ -23,7 +25,7 @@ const ownerJob = {
   progress: 0,
   status: "processing" as const,
   momentsFound: 0,
-  estimatedSecondsRemaining: 300,
+  estimatedSecondsRemaining: JOB_ESTIMATED_SECONDS,
   createdAt: Date.now(),
 };
 

--- a/__tests__/api/prices.xlm.test.ts
+++ b/__tests__/api/prices.xlm.test.ts
@@ -1,12 +1,10 @@
 /**
  * @jest-environment node
  */
-import { GET, _resetCache } from "@/app/api/prices/xlm/route";
+import { GET, _resetCache, CACHE_TTL_MS } from "@/app/api/prices/xlm/route";
 
 global.fetch = jest.fn();
 const mockFetch = global.fetch as jest.Mock;
-
-const FIVE_MIN_MS = 5 * 60 * 1000;
 
 beforeEach(() => {
   _resetCache();
@@ -55,7 +53,7 @@ describe("GET /api/prices/xlm", () => {
     });
 
     await GET();
-    jest.advanceTimersByTime(FIVE_MIN_MS + 1);
+    jest.advanceTimersByTime(CACHE_TTL_MS + 1);
 
     await GET();
     expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -68,7 +66,7 @@ describe("GET /api/prices/xlm", () => {
     });
     await GET(); // populate cache
 
-    jest.advanceTimersByTime(FIVE_MIN_MS + 1); // expire cache
+    jest.advanceTimersByTime(CACHE_TTL_MS + 1); // expire cache
 
     mockFetch.mockResolvedValueOnce({ ok: false, status: 429, json: async () => ({}) });
 

--- a/app/api/prices/xlm/route.ts
+++ b/app/api/prices/xlm/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
+import { PRICE_CACHE_TTL_MS } from "@/app/lib/constants";
 
 const COINGECKO_URL =
   "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd";
-const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_TTL_MS = PRICE_CACHE_TTL_MS;
+export { CACHE_TTL_MS };
 const FALLBACK_PRICE =
   parseFloat(process.env.NEXT_PUBLIC_XLM_FALLBACK_PRICE_USD ?? "0.12");
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -40,13 +40,14 @@ import { scanFile, VirusScanError, getScanConfig } from "@/app/lib/virusScan";
 import { checkCsrf } from "@/app/lib/csrf";
 import { jobStore } from "@/app/api/jobs/shared/jobStore";
 import { dispatchJob } from "@/app/lib/aiBackend";
+import { MAX_UPLOAD_SIZE_BYTES } from "@/app/lib/constants";
 
-const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
+export { MAX_UPLOAD_SIZE_BYTES };
 const ALLOWED_TYPES = ["video/mp4", "video/quicktime", "video/x-msvideo", "video/x-matroska"];
 const ALLOWED_EXTENSIONS = [".mp4", ".mov", ".avi", ".mkv"];
 
 function validateFile(file: File): string | null {
-  if (file.size > MAX_FILE_SIZE) {
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
     return `File "${file.name}" exceeds the maximum allowed size of 500 MB`;
   }
   const ext = "." + (file.name.split(".").pop()?.toLowerCase() ?? "");

--- a/app/hooks/useBalance.ts
+++ b/app/hooks/useBalance.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { BALANCE_REFRESH_INTERVAL_MS, PRICE_CACHE_TTL_MS } from "@/app/lib/constants";
 
 /**
  * Balance data structure
@@ -157,7 +158,7 @@ export async function getBalance(
   }
 }
 
-const DEFAULT_PRICE_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_PRICE_CACHE_TTL_MS = PRICE_CACHE_TTL_MS;
 const FALLBACK_XLM_PRICE_USD = parseFloat(
   process.env.NEXT_PUBLIC_XLM_FALLBACK_PRICE_USD ?? "0.12"
 );
@@ -248,7 +249,7 @@ export function useBalance(options: UseBalanceOptions) {
   const {
     publicKey,
     network = "TESTNET",
-    refreshInterval = 30000,
+    refreshInterval = BALANCE_REFRESH_INTERVAL_MS,
     autoRefresh = true,
     enableStreaming = true,
     priceCacheTtlMs = DEFAULT_PRICE_CACHE_TTL_MS,

--- a/app/hooks/useProcessingStatus.ts
+++ b/app/hooks/useProcessingStatus.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import { useProcessStore } from "@/app/store/processStore";
 import { ProcessStatus } from "@/app/store/types";
+import { JOB_ESTIMATED_SECONDS } from "@/app/lib/constants";
 
 interface JobStatus {
   progress: number;
@@ -136,7 +137,7 @@ export async function mockFetchJobStatus(jobId: string): Promise<JobStatus> {
       progress: 0,
       status: "processing",
       momentsFound: 0,
-      estimatedSecondsRemaining: 300,
+      estimatedSecondsRemaining: JOB_ESTIMATED_SECONDS,
     };
   }
 

--- a/app/hooks/useStellarTransaction.ts
+++ b/app/hooks/useStellarTransaction.ts
@@ -9,6 +9,7 @@ import {
   isInvokeContractBuildError,
 } from "@/app/lib/stellarOperations";
 import { captureSorobanNotSupportedWarning } from "@/app/lib/sentry";
+import { TRANSACTION_TIMEOUT_MS } from "@/app/lib/constants";
 
 /**
  * Stellar transaction status
@@ -115,7 +116,7 @@ export interface QueuedOperation {
 export function useStellarTransaction(options: StellarTransactionOptions = {}) {
   const {
     network = "testnet",
-    timeout = 30000,
+    timeout = TRANSACTION_TIMEOUT_MS,
     maxRetries = 3,
     onSuccess,
     onError,

--- a/app/hooks/useWalletHealth.ts
+++ b/app/hooks/useWalletHealth.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { ACTIVE_NETWORK_CONFIG, STELLAR_NETWORK } from "@/app/lib/networkConfig";
+import { EXCELLENT_LATENCY_THRESHOLD_MS } from "@/app/lib/constants";
 
 export type ConnectionQuality = "excellent" | "good" | "degraded" | "offline";
 
@@ -35,7 +36,7 @@ export interface WalletHealthData {
 }
 
 const QUALITY_THRESHOLDS = {
-  excellent: 300,  // < 300 ms
+  excellent: EXCELLENT_LATENCY_THRESHOLD_MS,  // < 300 ms
   good: 800,       // 300–800 ms
   degraded: 2000,  // 800–2000 ms
   // > 2000 ms or unreachable → offline

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,0 +1,27 @@
+// Upload limits
+export const MAX_UPLOAD_SIZE_BYTES = 500 * 1024 * 1024;
+
+// Crypto
+export const PBKDF2_ITERATIONS = 100000;
+
+// Balance & wallet
+export const BALANCE_REFRESH_INTERVAL_MS = 30000;
+export const TRANSACTION_TIMEOUT_MS = 30000;
+
+// Cache TTLs
+export const PRICE_CACHE_TTL_MS = 5 * 60 * 1000;
+export const DASHBOARD_CACHE_TTL_MS = 5 * 60 * 1000;
+export const EARNINGS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Jobs
+export const JOB_ESTIMATED_SECONDS = 300;
+
+// UI defaults
+export const DEBOUNCE_DEFAULT_DELAY_MS = 300;
+
+// Stellar
+export const BASE_BACKOFF_MS = 300;
+export const EXCELLENT_LATENCY_THRESHOLD_MS = 300;
+
+// Virus scan
+export const VIRUS_SCAN_DEFAULT_TIMEOUT_MS = 30000;

--- a/app/lib/secureStorage.ts
+++ b/app/lib/secureStorage.ts
@@ -1,3 +1,5 @@
+import { PBKDF2_ITERATIONS } from "./constants";
+
 const CRYPTO_SALT_KEY = 'clipcash_crypto_salt';
 
 let pendingDecryptionWarning: string | null = null;
@@ -59,7 +61,7 @@ const getCryptoKey = async (): Promise<CryptoKey> => {
     {
       name: 'PBKDF2',
       salt: new TextEncoder().encode(salt),
-      iterations: 100000,
+      iterations: PBKDF2_ITERATIONS,
       hash: 'SHA-256',
     },
     passwordMaterial,

--- a/app/lib/stellarTransaction.ts
+++ b/app/lib/stellarTransaction.ts
@@ -37,6 +37,7 @@
 
 import { STELLAR_NETWORKS, StellarNetwork } from "./embeddedWallet";
 import { StellarOperation, validateOperations } from "./stellarOperations";
+import { BASE_BACKOFF_MS } from "@/app/lib/constants";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -45,9 +46,6 @@ const MAX_SEQ_RETRIES = 3;
 
 /** Maximum retries for transient network errors */
 const MAX_NETWORK_RETRIES = 3;
-
-/** Base delay (ms) for exponential backoff */
-const BASE_BACKOFF_MS = 300;
 
 // ─── Error types ──────────────────────────────────────────────────────────────
 

--- a/app/lib/useDebounce.ts
+++ b/app/lib/useDebounce.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { DEBOUNCE_DEFAULT_DELAY_MS } from "@/app/lib/constants";
 
 /**
  * Debounces a value by the given delay (ms).
@@ -6,7 +7,7 @@ import { useState, useEffect } from "react";
  * stable for `delay` milliseconds — prevents excessive re-renders
  * on every keystroke.
  */
-export function useDebounce<T>(value: T, delay = 300): T {
+export function useDebounce<T>(value: T, delay = DEBOUNCE_DEFAULT_DELAY_MS): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {

--- a/app/lib/virusScan.ts
+++ b/app/lib/virusScan.ts
@@ -16,6 +16,8 @@
  *   VIRUS_SCAN_ENABLED           — "true" | "false" (default: "true" for prod, "false" for dev)
  */
 
+import { VIRUS_SCAN_DEFAULT_TIMEOUT_MS } from "@/app/lib/constants";
+
 export type ScanProvider = "clamav" | "virustotal" | "cloudmersive" | "disabled";
 
 export interface ScanResult {
@@ -56,7 +58,7 @@ function getProvider(): ScanProvider {
 function getScanTimeout(): number {
   const timeout = process.env.VIRUS_SCAN_TIMEOUT
     ? parseInt(process.env.VIRUS_SCAN_TIMEOUT, 10)
-    : 30000; // 30 seconds default
+    : VIRUS_SCAN_DEFAULT_TIMEOUT_MS; // 30 seconds default
   if (isNaN(timeout) || timeout <= 0) {
     throw new VirusScanError("VIRUS_SCAN_TIMEOUT must be a positive integer", "CONFIG_ERROR");
   }

--- a/app/store/dashboardStore.ts
+++ b/app/store/dashboardStore.ts
@@ -25,7 +25,9 @@ import type {
 // ─── Cache TTL ────────────────────────────────────────────────────────────────
 
 /** Re-use cached data for 5 minutes before hitting the API again */
-const CACHE_TTL_MS = 5 * 60 * 1000;
+import { DASHBOARD_CACHE_TTL_MS } from "@/app/lib/constants";
+const CACHE_TTL_MS = DASHBOARD_CACHE_TTL_MS;
+export { DASHBOARD_CACHE_TTL_MS };
 
 import { fetchDashboardFromAPI } from "./api";
 

--- a/app/store/earningsStore.ts
+++ b/app/store/earningsStore.ts
@@ -25,7 +25,9 @@ import type {
 
 // ─── Cache TTL ────────────────────────────────────────────────────────────────
 
-const CACHE_TTL_MS = 5 * 60 * 1000;
+import { EARNINGS_CACHE_TTL_MS } from "@/app/lib/constants";
+const CACHE_TTL_MS = EARNINGS_CACHE_TTL_MS;
+export { EARNINGS_CACHE_TTL_MS };
 
 import { fetchEarningsFromAPI } from "./api";
 

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -5,6 +5,7 @@ import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
 import DashboardHeader from "@/components/dashboard/DashboardHeader";
 import { useAutoStellarWallet } from "@/app/hooks/useAutoStellarWallet";
 import { useBalance, type AssetBalance } from "@/app/hooks/useBalance";
+import { BALANCE_REFRESH_INTERVAL_MS } from "@/app/lib/constants";
 import { useNetworkOverride } from "@/app/hooks/useNetworkOverride";
 import { getFreighterNetwork } from "@/app/lib/networkConfig";
 import {
@@ -203,7 +204,7 @@ export default function WalletPortfolioPage() {
   const { balance, isLoading, error, refresh } = useBalance({
     publicKey,
     network: freighterNetwork,
-    refreshInterval: 30000,
+    refreshInterval: BALANCE_REFRESH_INTERVAL_MS,
   });
 
   const history = useMockHistory(balance?.xlmRaw ?? 0);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,17 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
-  ...storybook.configs["flat/recommended"]
+  ...storybook.configs["flat/recommended"],
+  {
+    files: ["app/**/*.ts", "app/**/*.tsx"],
+    rules: {
+      "no-magic-numbers": ["warn", {
+        ignore: [0, 1, 2, 3, 5, 8, -1, 100, 1000, 1024, 60, 24, 7, 12, 200, 201, 204, 301, 302, 400, 401, 403, 404, 429, 500, 502, 503],
+        ignoreArrayIndexes: true,
+        ignoreDefaultValues: true,
+      }],
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
What was done:
- Created app/lib/constants.ts with centralized named constants
- Replaced 500 * 1024 * 1024 → MAX_UPLOAD_SIZE_BYTES in upload route
- Replaced 100000 → PBKDF2_ITERATIONS in secureStorage
- Replaced 30000 → BALANCE_REFRESH_INTERVAL_MS / TRANSACTION_TIMEOUT_MS / VIRUS_SCAN_DEFAULT_TIMEOUT_MS
- Replaced 5 * 60 * 1000 → PRICE_CACHE_TTL_MS / DASHBOARD_CACHE_TTL_MS / EARNINGS_CACHE_TTL_MS
- Replaced 300 → JOB_ESTIMATED_SECONDS / DEBOUNCE_DEFAULT_DELAY_MS / EXCELLENT_LATENCY_THRESHOLD_MS / BASE_BACKOFF_MS
- Updated tests to import constants instead of hardcoding values
- Enabled no-magic-numbers ESLint rule as warning (scoped to app/**/*.ts(x))
- All 23 tests pass

closes #542