### PR TITLE
fix: resolve four open-source contribution issues

### DIFF
--- a/__tests__/lib/cryptoUtils.test.ts
+++ b/__tests__/lib/cryptoUtils.test.ts
@@ -1,0 +1,69 @@
+import { encryptWithPassword, decryptWithPassword } from "@/app/lib/cryptoUtils";
+
+describe("encryptWithPassword / decryptWithPassword", () => {
+  it("encrypts and decrypts a plaintext string correctly", async () => {
+    const plaintext = "my-secret-stellar-key-SABCDEFGHIJKLMNOP";
+    const password = "strong-recovery-password";
+
+    const encrypted = await encryptWithPassword(plaintext, password);
+    expect(typeof encrypted).toBe("string");
+    expect(encrypted.length).toBeGreaterThan(0);
+
+    const decrypted = await decryptWithPassword(encrypted, password);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("produces different ciphertexts for the same plaintext (nonce/salt randomness)", async () => {
+    const plaintext = "consistent-data";
+    const password = "same-password";
+
+    const enc1 = await encryptWithPassword(plaintext, password);
+    const enc2 = await encryptWithPassword(plaintext, password);
+
+    expect(enc1).not.toBe(enc2);
+  });
+
+  it("throws when decrypting with the wrong password", async () => {
+    const plaintext = "secret-message";
+    const encrypted = await encryptWithPassword(plaintext, "correct-password");
+
+    await expect(decryptWithPassword(encrypted, "wrong-password")).rejects.toThrow();
+  });
+
+  it("throws when decrypting corrupted ciphertext", async () => {
+    await expect(decryptWithPassword("not-valid-base64!!", "password")).rejects.toThrow();
+  });
+
+  it("handles empty string plaintext", async () => {
+    const encrypted = await encryptWithPassword("", "password");
+    const decrypted = await decryptWithPassword(encrypted, "password");
+    expect(decrypted).toBe("");
+  });
+
+  it("handles special characters in password", async () => {
+    const plaintext = "wallet-mnemonic-phrase";
+    const password = "p@ssw0rd!#$%^&*()_+-=[]{}|;:',.<>?/~`";
+
+    const encrypted = await encryptWithPassword(plaintext, password);
+    const decrypted = await decryptWithPassword(encrypted, password);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("handles unicode characters in plaintext", async () => {
+    const plaintext = "café-über-漢字";
+    const password = "unicode-pass";
+
+    const encrypted = await encryptWithPassword(plaintext, password);
+    const decrypted = await decryptWithPassword(encrypted, password);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("handles long plaintext (wallet-size data)", async () => {
+    const plaintext = "x".repeat(1024);
+    const password = "long-data-password";
+
+    const encrypted = await encryptWithPassword(plaintext, password);
+    const decrypted = await decryptWithPassword(encrypted, password);
+    expect(decrypted).toBe(plaintext);
+  });
+});

--- a/__tests__/mocks/processingStatus.ts
+++ b/__tests__/mocks/processingStatus.ts
@@ -1,0 +1,33 @@
+import type { ProcessStatus } from "@/app/store/types";
+import { JOB_ESTIMATED_SECONDS } from "@/app/lib/constants";
+
+interface JobStatus {
+  progress: number;
+  status: ProcessStatus;
+  momentsFound: number;
+  estimatedSecondsRemaining: number | null;
+}
+
+/**
+ * Mock API endpoint for development/testing
+ * This simulates a job status response
+ * @param jobId - Specific job tracking reference used to identify historical storage dumps.
+ * @returns Instantly wrapped async simulated progress state structure.
+ */
+export async function mockFetchJobStatus(jobId: string): Promise<JobStatus> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const stored = localStorage.getItem(`job_${jobId}`);
+  const jobData = stored ? JSON.parse(stored) : null;
+
+  if (!jobData) {
+    return {
+      progress: 0,
+      status: "processing",
+      momentsFound: 0,
+      estimatedSecondsRemaining: JOB_ESTIMATED_SECONDS,
+    };
+  }
+
+  return jobData;
+}

--- a/app/hooks/useProcessingStatus.ts
+++ b/app/hooks/useProcessingStatus.ts
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import { useProcessStore, selectHasHydrated } from "@/app/store/processStore";
 import { ProcessStatus } from "@/app/store/types";
-import { JOB_ESTIMATED_SECONDS } from "@/app/lib/constants";
 import { logger } from "@/app/lib/logger";
 
 /** Real-time data schema updating background pipeline progress metrics */
@@ -203,28 +202,4 @@ export function useProcessingStatus(jobId: string | null, enabled: boolean = tru
   return { stopPolling: stopAll };
 }
 
-/**
- * Mock API endpoint for development/testing
- * This simulates a job status response
- * * @param jobId - Specific job tracking reference used to identify historical storage dumps.
- * @returns Instantly wrapped async simulated progress state structure.
- */
-export async function mockFetchJobStatus(jobId: string): Promise<JobStatus> {
-  // Simulate network delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
 
-  // For demo purposes, simulate progress
-  const stored = localStorage.getItem(`job_${jobId}`);
-  const jobData = stored ? JSON.parse(stored) : null;
-
-  if (!jobData) {
-    return {
-      progress: 0,
-      status: "processing",
-      momentsFound: 0,
-      estimatedSecondsRemaining: JOB_ESTIMATED_SECONDS,
-    };
-  }
-
-  return jobData;
-}

--- a/app/lib/cryptoUtils.ts
+++ b/app/lib/cryptoUtils.ts
@@ -1,0 +1,98 @@
+const SALT_LENGTH = 16;
+const IV_LENGTH = 12;
+const PBKDF2_ITERATIONS = 100000;
+const COMBINED_SALT_IV_END = SALT_LENGTH + IV_LENGTH;
+
+/**
+ * Encrypts plaintext using a password-derived key via Web Crypto API.
+ *
+ * @param data - The plaintext string to encrypt.
+ * @param password - The user-supplied password used to derive the encryption key.
+ * @returns A Base64-encoded string containing the salt, IV, and ciphertext.
+ */
+export async function encryptWithPassword(data: string, password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"]
+  );
+
+  const encoded = encoder.encode(data);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    encoded
+  );
+
+  const combined = new Uint8Array(salt.length + iv.length + ciphertext.byteLength);
+  combined.set(salt, 0);
+  combined.set(iv, salt.length);
+  combined.set(new Uint8Array(ciphertext), salt.length + iv.length);
+
+  return btoa(String.fromCharCode(...combined));
+}
+
+/**
+ * Decrypts a ciphertext produced by encryptWithPassword using the same password.
+ *
+ * @param encryptedData - The Base64-encoded output from encryptWithPassword.
+ * @param password - The user-supplied password used to derive the decryption key.
+ * @returns The original plaintext string.
+ * @throws {Error} If decryption fails due to an incorrect password or corrupted data.
+ */
+export async function decryptWithPassword(encryptedData: string, password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const combined = Uint8Array.from(atob(encryptedData), (c) => c.charCodeAt(0));
+
+  const salt = combined.slice(0, SALT_LENGTH);
+  const iv = combined.slice(SALT_LENGTH, COMBINED_SALT_IV_END);
+  const ciphertext = combined.slice(COMBINED_SALT_IV_END);
+
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"]
+  );
+
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ciphertext
+  );
+
+  return new TextDecoder().decode(decrypted);
+}

--- a/app/recovery/page.tsx
+++ b/app/recovery/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { useWallet } from "@/components/wallet/WalletProvider";
 import { MockApi } from "@/app/lib/mockApi";
 import { restoreWalletFromMnemonic } from "@/app/lib/stellar";
-import { decryptWithPassword } from "@/components/SocialRecoveryConfig";
+import { decryptWithPassword } from "@/app/lib/cryptoUtils";
 import { secureStorage } from "@/app/lib/secureStorage";
 import {
   Shield,

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -1,3 +1,6 @@
+// TODO(issue #7): Once the real API backend is resolved, replace the re-exports
+// below with direct API calls (e.g. to /api/v2/dashboard). Until then, this barrel
+// delegates to the single source of truth at app/lib/apiClient.ts.
 export {
   fetchDashboardFromAPI,
   fetchUserFromAPI,

--- a/components/SocialRecoveryConfig/index.tsx
+++ b/components/SocialRecoveryConfig/index.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Shield,
+  Users,
+  Plus,
+  Trash2,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  Save,
+} from "lucide-react";
+import { useToast } from "@/hooks/useToast";
+import { encryptWithPassword } from "@/app/lib/cryptoUtils";
+import { splitSecret } from "@/app/lib/shamirRecovery";
+import { MockApi } from "@/app/lib/mockApi";
+import { secureStorage } from "@/app/lib/secureStorage";
+
+export { encryptWithPassword, decryptWithPassword } from "@/app/lib/cryptoUtils";
+
+export default function SocialRecoveryConfig() {
+  const { showToast } = useToast();
+  const [guardians, setGuardians] = useState<{ email: string; name: string }[]>([
+    { email: "", name: "" },
+  ]);
+  const [recoveryPassword, setRecoveryPassword] = useState("");
+  const [threshold, setThreshold] = useState(2);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  const addGuardian = () => {
+    if (guardians.length >= 6) return;
+    setGuardians([...guardians, { email: "", name: "" }]);
+  };
+
+  const removeGuardian = (index: number) => {
+    if (guardians.length <= 1) return;
+    const updated = guardians.filter((_, i) => i !== index);
+    setGuardians(updated);
+    if (threshold > updated.length) {
+      setThreshold(Math.max(2, updated.length));
+    }
+  };
+
+  const updateGuardian = (index: number, field: "email" | "name", value: string) => {
+    const updated = [...guardians];
+    updated[index][field] = value;
+    setGuardians(updated);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSaved(false);
+
+    const validGuardians = guardians.filter((g) => g.email.trim());
+    if (validGuardians.length < 2) {
+      setError("Add at least two guardians with email addresses.");
+      return;
+    }
+    if (!recoveryPassword) {
+      setError("Please set a recovery password.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const stored = await secureStorage.getItem("clipcash_wallet");
+      if (!stored) {
+        throw new Error("No wallet found. Please connect or create a wallet first.");
+      }
+
+      const parsed = JSON.parse(stored);
+      const backupPayload = parsed.stellarSecret || parsed.stellarMnemonic;
+      if (!backupPayload) {
+        throw new Error("No wallet secret or mnemonic available for backup.");
+      }
+
+      const encryptedBackup = await encryptWithPassword(backupPayload, recoveryPassword);
+      const shares = splitSecret(encryptedBackup, {
+        shares: validGuardians.length,
+        threshold,
+      });
+
+      await MockApi.saveSocialRecoveryConfig({
+        email: parsed.email || "user@clipcash.ai",
+        guardians: validGuardians.map((g) => g.email),
+        shares,
+        threshold,
+        encryptedBackup,
+      });
+
+      setSaved(true);
+      showToast("Social recovery configuration saved successfully.", "success");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to save social recovery configuration.";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5 border border-white/5 rounded-2xl p-5 bg-black/30">
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-full bg-brand/10 border border-brand/20 flex items-center justify-center text-brand shrink-0">
+          <Shield className="w-5 h-5" />
+        </div>
+        <div>
+          <p className="font-bold text-white text-sm">Social Recovery Configuration</p>
+          <p className="text-[10px] text-muted-foreground leading-relaxed">
+            Set up trusted guardians who can help you recover your wallet in an emergency.
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="p-3 rounded-xl bg-red-950/40 border border-red-500/20 flex gap-2 items-start">
+          <AlertCircle className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
+          <p className="text-[11px] text-red-300 leading-normal">{error}</p>
+        </div>
+      )}
+
+      {saved && (
+        <div className="p-3 rounded-xl bg-emerald-950/40 border border-emerald-500/20 flex gap-2 items-start">
+          <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 shrink-0 mt-0.5" />
+          <p className="text-[11px] text-emerald-300 leading-normal">
+            Social recovery configuration saved. Your encrypted backup has been split among your guardians.
+          </p>
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-4">
+        <div className="space-y-2">
+          <label className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+            <Users className="w-3.5 h-3.5 text-brand" /> Trusted Guardians
+          </label>
+
+          {guardians.map((guardian, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                type="text"
+                placeholder="Guardian name"
+                value={guardian.name}
+                onChange={(e) => updateGuardian(i, "name", e.target.value)}
+                className="flex-1 bg-[#111613] border border-white/5 text-white focus:border-brand/40 rounded-xl px-3 py-2.5 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition-colors"
+              />
+              <input
+                type="email"
+                placeholder="Guardian email"
+                value={guardian.email}
+                onChange={(e) => updateGuardian(i, "email", e.target.value)}
+                className="flex-[1.5] bg-[#111613] border border-white/5 text-white focus:border-brand/40 rounded-xl px-3 py-2.5 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition-colors"
+              />
+              <button
+                type="button"
+                onClick={() => removeGuardian(i)}
+                disabled={guardians.length <= 1}
+                className="p-2.5 rounded-xl bg-white/5 border border-white/5 text-muted-foreground hover:text-red-400 hover:border-red-500/25 transition-colors cursor-pointer disabled:opacity-30"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={addGuardian}
+            disabled={guardians.length >= 6}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-white/5 border border-white/5 text-muted-foreground hover:text-brand hover:border-brand/25 transition-colors text-[10px] font-bold cursor-pointer disabled:opacity-30"
+          >
+            <Plus className="w-3 h-3" />
+            Add Guardian
+          </button>
+        </div>
+
+        {guardians.length >= 2 && (
+          <div className="p-3 rounded-xl bg-white/[0.01] border border-white/5">
+            <label className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider mb-2">
+              Recovery Threshold
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: guardians.length }, (_, i) => i + 2).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setThreshold(t)}
+                  className={`px-3 py-1.5 rounded-lg text-[10px] font-bold transition-colors cursor-pointer ${
+                    threshold === t
+                      ? "bg-brand text-black"
+                      : "bg-white/5 text-muted-foreground hover:text-white"
+                  }`}
+                >
+                  {t} of {guardians.length}
+                </button>
+              ))}
+            </div>
+            <p className="text-[9px] text-muted-foreground mt-2">
+              You will need approval from {threshold} out of {guardians.length} guardians to recover your wallet.
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <label className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+            Recovery Password
+          </label>
+          <input
+            type="password"
+            placeholder="Choose a strong password to encrypt your backup"
+            value={recoveryPassword}
+            onChange={(e) => setRecoveryPassword(e.target.value)}
+            className="w-full bg-[#111613] border border-white/5 text-white focus:border-brand/40 rounded-xl px-4 py-2.5 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition-colors"
+          />
+          <p className="text-[9px] text-muted-foreground">
+            This password encrypts your wallet backup. You will need it when recovering through guardians.
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="w-full py-3 rounded-xl bg-brand hover:bg-brand-hover text-black font-extrabold text-xs flex items-center justify-center gap-2 transition-all active:scale-[0.98] cursor-pointer disabled:opacity-40"
+        >
+          {saving ? (
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Saving Configuration...
+            </>
+          ) : (
+            <>
+              <Save className="w-3.5 h-3.5" />
+              Save Social Recovery Setup
+            </>
+          )}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,49 @@
+# Security
+
+## Content Security Policy (CSP)
+
+When deploying to production, the following Content Security Policy directives must include the analytics and resource domains listed below. Without these entries, analytics providers will be silently blocked by the browser.
+
+### script-src
+
+The following domains load JavaScript from external analytics providers and must be present in `script-src`:
+
+- `https://www.googletagmanager.com` — Google Tag Manager (GA4 script loader)
+- `https://plausible.io` — Plausible Analytics script
+
+### connect-src
+
+The following domains receive beacon / fetch requests for analytics data collection:
+
+- `https://www.google-analytics.com` — GA4 data sends
+- `https://plausible.io` — Plausible event API
+
+### Additional Domains
+
+These additional domains are used by the application and must appear in the appropriate CSP directives:
+
+| Directive   | Domain                     | Purpose                          |
+|------------|----------------------------|----------------------------------|
+| `img-src`  | `https://api.dicebear.com` | Avatar generation                |
+| `img-src`  | `https://images.unsplash.com` | Stock photography               |
+| `connect-src` | `https://api.coingecko.com` | XLM / Stellar price data        |
+
+### Example CSP Header (Production)
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' https://www.googletagmanager.com https://plausible.io;
+  connect-src 'self' https://www.google-analytics.com https://plausible.io https://api.coingecko.com;
+  img-src 'self' data: https://api.dicebear.com https://images.unsplash.com;
+  style-src 'self' 'unsafe-inline';
+  frame-ancestors 'none';
+```
+
+### Testing
+
+After configuring CSP headers, verify that no console violations appear when each analytics provider is enabled. Use the following procedure:
+
+1. Set `NEXT_PUBLIC_ANALYTICS_PROVIDER=ga4` and verify GA4 events appear in the network tab with no CSP errors.
+2. Set `NEXT_PUBLIC_ANALYTICS_PROVIDER=plausible` and verify Plausible events appear in the network tab with no CSP errors.
+3. Confirm that `cookie-consent` changes trigger and revoke analytics tracking without CSP violations.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,38 @@ const eslintConfig = defineConfig([
       }],
     },
   },
+  {
+    files: ["app/hooks/**/*.ts", "app/hooks/**/*.tsx", "app/lib/**/*.ts", "app/lib/**/*.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ExportNamedDeclaration > FunctionDeclaration[id.name=/^mock/]",
+          message: "Functions starting with 'mock' must not be exported from production source files. Move them to __tests__/mocks/ or __mocks__/.",
+        },
+        {
+          selector: "ExportNamedDeclaration > VariableDeclaration > VariableDeclarator[id.name=/^mock/]",
+          message: "Variables/constants starting with 'mock' must not be exported from production source files. Move them to __tests__/mocks/ or __mocks__/.",
+        },
+      ],
+    },
+  },
+  {
+    files: ["app/store/**/*.ts", "app/store/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/mockApi*", "**/mockApi/**"],
+              message: "Store files must not import from mockApi directly. Use the ./api barrel export instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
closes #640 
closes #641 
closes #642 
closes #643 

## Summary

Resolves four open-source contribution issues in a single PR.

---

### 1. Remove `mockFetchJobStatus` from production source + ESLint rule

**Problem:** `useProcessingStatus.ts` exported `mockFetchJobStatus` — a development helper that reads job state from `localStorage`. Mock helpers should not be exported from production source files.

**Changes:**
- Removed `mockFetchJobStatus` from `app/hooks/useProcessingStatus.ts`
- Moved it to `__tests__/mocks/processingStatus.ts`
- Added ESLint `no-restricted-syntax` rule: exports starting with `mock` in `app/hooks/` or `app/lib/` now fail lint
- Removed the now-unused `JOB_ESTIMATED_SECONDS` import from `useProcessingStatus.ts`

---

### 2. Move crypto utilities out of component files

**Problem:** `app/recovery/page.tsx` imported `decryptWithPassword` from `@/components/SocialRecoveryConfig` — a utility function imported from a UI component file, violating separation of concerns.

**Changes:**
- Created `app/lib/cryptoUtils.ts` with `encryptWithPassword` and `decryptWithPassword` using Web Crypto API (PBKDF2 + AES-GCM, 100K iterations)
- Created `components/SocialRecoveryConfig/index.tsx` — a React component for social recovery configuration that re-exports both crypto functions from `cryptoUtils.ts`
- Updated `app/recovery/page.tsx` to import `decryptWithPassword` from `@/app/lib/cryptoUtils`
- Added 8 unit tests in `__tests__/lib/cryptoUtils.test.ts` covering: encrypt/decrypt roundtrip, nonce randomness, wrong password rejection, corrupted data, empty strings, special character passwords, unicode, and large payloads

---

### 3. Document required CSP domains for analytics

**Problem:** `analytics.ts` dynamically injects `<script>` tags for Google Analytics (`googletagmanager.com`) and Plausible (`plausible.io`). These domains were not documented for CSP configuration.

**Changes:**
- Created `docs/SECURITY.md` documenting all required CSP directives:
  - `script-src`: `https://www.googletagmanager.com`, `https://plausible.io`
  - `connect-src`: `https://www.google-analytics.com`, `https://plausible.io`
  - Also documents existing domains (`api.dicebear.com`, `images.unsplash.com`, `api.coingecko.com`)
  - Includes example production CSP header and testing procedures

---

### 4. API barrel file cleanup

**Problem:** `app/store/api.ts` is a barrel re-exporting API functions but lacked context about its intended role.

**Changes:**
- Added `TODO(issue #7)` comment explaining the barrel's role pending real API backend resolution
- Added ESLint `no-restricted-imports` rule: store files importing `mockApi` directly (outside `./api`) now fail lint

---

## Testing

✓ 8/8 cryptoUtils tests pass
✓ 36/36 store tests pass
✓ No TypeScript errors in modified files
✓ ESLint rules verified valid

## Files Changed

| File | Action |
|------|--------|
| `app/hooks/useProcessingStatus.ts` | Modified — removed `mockFetchJobStatus` |
| `app/lib/cryptoUtils.ts` | Added — encrypt/decrypt utilities |
| `app/recovery/page.tsx` | Modified — updated crypto import path |
| `app/store/api.ts` | Modified — added TODO comment |
| `components/SocialRecoveryConfig/index.tsx` | Added — component + re-exports |
| `docs/SECURITY.md` | Added — CSP domain documentation |
| `eslint.config.mjs` | Modified — two new lint rules |
| `__tests__/lib/cryptoUtils.test.ts` | Added — unit tests |
| `__tests__/mocks/processingStatus.ts` | Added — relocated mock helper |