### PR TITLE
feat: edge middleware auth, encrypted key export, AI transform store …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,11 @@ NEXT_PUBLIC_PLAUSIBLE_DOMAIN=clipcash.ai
 # Custom analytics endpoint (if using custom)
 NEXT_PUBLIC_ANALYTICS_ENDPOINT=https://your-analytics-api.com/events
 
+# ─── AI Video Transformation (optional) ──────────────────────────────────────
+# Comma-separated list of available transformation styles.
+# These are validated server-side in /api/transform.
+NEXT_PUBLIC_TRANSFORM_STYLES=anime,cinematic,sketch,watercolor
+
 # ─── Virus Scanning ───────────────────────────────────────────────────────────
 # Virus scanning is enabled by default in production, disabled in development
 # Files are stored in quarantine/ prefix before scanning and moved only if clean.

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useWallet } from "@/components/WalletProvider";
 import SocialRecoveryConfig from "@/components/SocialRecoveryConfig";
 import WalletConnectButton from "@/components/WalletConnectButton";
-import { Bell, BellOff, Check, X, Key, Wallet, Shield, Copy, Eye, EyeOff, Globe, Moon, Sun, TimerOff } from "lucide-react";
+import { Bell, BellOff, Check, X, Key, Wallet, Shield, Copy, Eye, EyeOff, Globe, Moon, Sun, TimerOff, Lock, Download } from "lucide-react";
 import Link from "next/link";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -17,6 +17,7 @@ import {
 import Skeleton from "@/components/ui/Skeleton";
 import TrustlineManager from "@/components/wallet/TrustlineManager";
 import { useTheme } from "@/components/theme-provider";
+import { encryptWithPassword } from "@/app/lib/cryptoUtils";
 
 export default function SettingsPage() {
   const { showToast } = useToast();
@@ -38,6 +39,34 @@ export default function SettingsPage() {
   const [copiedKey, setCopiedKey] = useState(false);
   const [mnemonicCopied, setMnemonicCopied] = useState(false);
   const [mnemonicClipboardCountdown, setMnemonicClipboardCountdown] = useState(0);
+
+  // ── Encrypted export modal state ──────────────────────────────────────────
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [exportPassword, setExportPassword] = useState("");
+  const [exportPasswordConfirm, setExportPasswordConfirm] = useState("");
+  const [exportError, setExportError] = useState("");
+  const [exportLoading, setExportLoading] = useState(false);
+
+  // Auto-clear the key from view 15 seconds after reveal
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleRevealKey = () => {
+    setShowPrivateKey(true);
+    if (revealTimerRef.current) clearTimeout(revealTimerRef.current);
+    revealTimerRef.current = setTimeout(() => {
+      setShowPrivateKey(false);
+      navigator.clipboard.writeText("").catch(() => {});
+    }, 15_000);
+  };
+  const handleHideKey = () => {
+    setShowPrivateKey(false);
+    if (revealTimerRef.current) {
+      clearTimeout(revealTimerRef.current);
+      revealTimerRef.current = null;
+    }
+  };
+  useEffect(() => () => {
+    if (revealTimerRef.current) clearTimeout(revealTimerRef.current);
+  }, []);
 
   useEffect(() => {
     if (user?.walletNetwork && user.walletNetwork !== walletNetwork) {
@@ -127,6 +156,51 @@ export default function SettingsPage() {
     setCopiedKey(true);
     showToast("Secret key copied to clipboard", "success");
     setTimeout(() => setCopiedKey(false), 2000);
+  };
+
+  const handleEncryptedExport = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setExportError("");
+
+    if (exportPassword.length < 8) {
+      setExportError("Password must be at least 8 characters.");
+      return;
+    }
+    if (exportPassword !== exportPasswordConfirm) {
+      setExportError("Passwords do not match.");
+      return;
+    }
+    if (!stellarSecret) return;
+
+    setExportLoading(true);
+    try {
+      const encrypted = await encryptWithPassword(stellarSecret, exportPassword);
+      const backup = {
+        _instructions:
+          "ClipCash encrypted wallet backup. Import via Settings → Advanced Wallet Mode → Import, or Recovery page → Encrypted Backup tab. Requires the password used during export.",
+        version: 1,
+        createdAt: new Date().toISOString(),
+        ciphertext: encrypted,
+      };
+      const blob = new Blob([JSON.stringify(backup, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "clipcash-wallet-backup.enc.json";
+      a.click();
+      URL.revokeObjectURL(url);
+
+      setExportModalOpen(false);
+      setExportPassword("");
+      setExportPasswordConfirm("");
+      showToast("Encrypted backup downloaded successfully.", "success");
+    } catch {
+      setExportError("Encryption failed. Please try again.");
+    } finally {
+      setExportLoading(false);
+    }
   };
 
   const mnemonicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -469,7 +543,7 @@ export default function SettingsPage() {
                             </div>
                             <div className="flex gap-2 shrink-0 items-end flex-wrap md:flex-nowrap">
                               <button
-                                onClick={() => setShowPrivateKey(!showPrivateKey)}
+                                onClick={() => (showPrivateKey ? handleHideKey() : handleRevealKey())}
                                 className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-xs font-bold hover:text-brand hover:border-brand/30 transition-all flex items-center gap-1 cursor-pointer"
                               >
                                 {showPrivateKey ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
@@ -478,19 +552,15 @@ export default function SettingsPage() {
 
                               <button
                                 onClick={() => {
-                                  // minimal client-side enforcement; full flow implemented in a modal in follow-up PR if needed
-                                  if (!stellarSecret) return;
-                                  const ok1 = window.confirm("Warning: This is your raw Stellar Secret Key. Anyone with it controls your funds. Continue?");
-                                  if (!ok1) return;
-                                  const ok2 = window.confirm("Last chance: Click OK to download an encrypted backup. Your password is required.");
-                                  if (!ok2) return;
-                                  // encrypted download is handled by a future secure modal; for now, we block raw copy via this button
-                                  showToast("Encrypted export will be available in the next step.", "success");
+                                  setExportModalOpen(true);
+                                  setExportError("");
+                                  setExportPassword("");
+                                  setExportPasswordConfirm("");
                                 }}
                                 className="px-3 py-2 rounded-xl bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all flex items-center gap-1 cursor-pointer"
                                 disabled={!stellarSecret}
                               >
-                                <Key className="w-3.5 h-3.5" aria-hidden="true" />
+                                <Download className="w-3.5 h-3.5" aria-hidden="true" />
                                 Export (Encrypted)
                               </button>
 
@@ -636,5 +706,84 @@ export default function SettingsPage() {
             </>
           )}
         </div>
+
+      {/* ── Encrypted Export Modal ─────────────────────────────────────────── */}
+      {exportModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="export-modal-title"
+        >
+          <div className="w-full max-w-sm bg-[#080B0A] border border-white/10 rounded-2xl p-6 shadow-2xl relative">
+            <button
+              onClick={() => setExportModalOpen(false)}
+              className="absolute top-4 right-4 text-muted-foreground hover:text-white transition-colors cursor-pointer"
+              aria-label="Close export modal"
+            >
+              <X className="w-4 h-4" />
+            </button>
+
+            <div className="flex items-center gap-3 mb-5">
+              <div className="w-10 h-10 rounded-xl bg-brand/10 border border-brand/20 flex items-center justify-center text-brand shrink-0">
+                <Lock className="w-5 h-5" />
+              </div>
+              <div>
+                <h2 id="export-modal-title" className="font-bold text-white text-sm">Export Encrypted Backup</h2>
+                <p className="text-[11px] text-muted-foreground mt-0.5">Set a strong password to protect your secret key.</p>
+              </div>
+            </div>
+
+            <form onSubmit={handleEncryptedExport} className="space-y-4">
+              <div className="space-y-1.5">
+                <label htmlFor="export-password" className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+                  Encryption Password
+                </label>
+                <input
+                  id="export-password"
+                  type="password"
+                  placeholder="Min. 8 characters"
+                  value={exportPassword}
+                  onChange={(e) => setExportPassword(e.target.value)}
+                  className="w-full bg-input border border-white/5 text-white focus:border-brand/40 rounded-xl px-4 py-3 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition-colors"
+                  autoComplete="new-password"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label htmlFor="export-password-confirm" className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+                  Confirm Password
+                </label>
+                <input
+                  id="export-password-confirm"
+                  type="password"
+                  placeholder="Re-enter password"
+                  value={exportPasswordConfirm}
+                  onChange={(e) => setExportPasswordConfirm(e.target.value)}
+                  className="w-full bg-input border border-white/5 text-white focus:border-brand/40 rounded-xl px-4 py-3 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition-colors"
+                  autoComplete="new-password"
+                />
+              </div>
+
+              {exportError && (
+                <p className="text-xs text-red-400 font-semibold">{exportError}</p>
+              )}
+
+              <div className="bg-yellow-500/5 border border-yellow-500/20 rounded-xl p-3 text-[10px] text-yellow-300 leading-relaxed">
+                <strong>Important:</strong> If you lose this password, your backup cannot be decrypted. Store both the file and password safely offline.
+              </div>
+
+              <button
+                type="submit"
+                disabled={exportLoading || !exportPassword || !exportPasswordConfirm}
+                className="w-full py-3.5 rounded-xl bg-brand text-black text-xs font-extrabold hover:bg-brand-hover transition-all flex items-center justify-center gap-2 cursor-pointer disabled:opacity-50"
+              >
+                <Download className="w-3.5 h-3.5" />
+                {exportLoading ? "Encrypting…" : "Download clipcash-wallet-backup.enc.json"}
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
   );
 }

--- a/app/(dashboard)/transform/[id]/page.tsx
+++ b/app/(dashboard)/transform/[id]/page.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  AlertCircle,
+  CheckCircle,
+  ChevronRight,
+  Clock,
+  Download,
+  Loader2,
+  Pause,
+  Play,
+  RefreshCw,
+  Sparkles,
+  Upload,
+  Wand2,
+  X,
+} from "lucide-react";
+import { useTransformStore, selectJobById, selectTransformHasHydrated } from "@/app/store/transformStore";
+import { useTransformStatus } from "@/app/hooks/useTransformStatus";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatEta(seconds: number | null | undefined): string {
+  if (seconds == null) return "Calculating…";
+  if (seconds <= 0) return "Almost done…";
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s}s remaining` : `${s}s remaining`;
+}
+
+function styleLabel(style: string): string {
+  return style.charAt(0).toUpperCase() + style.slice(1);
+}
+
+// ─── Side-by-side video player ────────────────────────────────────────────────
+
+interface ComparisonPlayerProps {
+  originalSrc: string;
+  transformedSrc: string;
+}
+
+function ComparisonPlayer({ originalSrc, transformedSrc }: ComparisonPlayerProps) {
+  const origRef = useRef<HTMLVideoElement>(null);
+  const transRef = useRef<HTMLVideoElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toggle = () => {
+    const orig = origRef.current;
+    const trans = transRef.current;
+    if (!orig || !trans) return;
+    if (playing) {
+      orig.pause();
+      trans.pause();
+    } else {
+      orig.play().catch(() => {});
+      trans.play().catch(() => {});
+    }
+    setPlaying(!playing);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <span className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">Original</span>
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            ref={origRef}
+            src={originalSrc}
+            className="w-full rounded-2xl border border-white/10 bg-black aspect-video object-contain"
+            playsInline
+            loop
+          />
+        </div>
+        <div className="space-y-2">
+          <span className="text-[11px] font-bold text-brand uppercase tracking-wider">Transformed</span>
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            ref={transRef}
+            src={transformedSrc}
+            className="w-full rounded-2xl border border-brand/20 bg-black aspect-video object-contain"
+            playsInline
+            loop
+          />
+        </div>
+      </div>
+      <div className="flex justify-center">
+        <button
+          onClick={toggle}
+          className="flex items-center gap-2 px-6 py-2.5 rounded-full bg-brand text-black text-xs font-bold hover:bg-brand-hover transition-all"
+        >
+          {playing ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+          {playing ? "Pause" : "Play"} Both
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default function TransformProgressPage() {
+  const params = useParams();
+  const router = useRouter();
+  const jobId = typeof params.id === "string" ? params.id : null;
+
+  const hasHydrated = useTransformStore(selectTransformHasHydrated);
+  const job = useTransformStore(jobId ? selectJobById(jobId) : () => undefined);
+
+  // Poll for live progress until terminal status
+  const isTerminal = job?.status === "complete" || job?.status === "error";
+  useTransformStatus(jobId, hasHydrated && !isTerminal);
+
+  // Derived values
+  const progress = job?.progress ?? 0;
+  const status = job?.status ?? "queued";
+  const style = job?.style ?? "";
+  const previewUrl = job?.previewUrl ?? null;
+  const resultUrl = job?.resultUrl ?? null;
+  const errorMessage = job?.errorMessage;
+
+  // ETA tracking — smoothed; store doesn't carry this directly so we track via progress deltas
+  const [eta, setEta] = useState<number | null>(null);
+  const lastProgressRef = useRef<{ progress: number; time: number } | null>(null);
+
+  useEffect(() => {
+    if (status !== "processing") return;
+    const now = Date.now();
+    const prev = lastProgressRef.current;
+    if (prev && progress > prev.progress) {
+      const elapsed = (now - prev.time) / 1000;
+      const rate = (progress - prev.progress) / elapsed; // % per second
+      const remaining = (100 - progress) / rate;
+      setEta(Math.round(remaining));
+    }
+    lastProgressRef.current = { progress, time: now };
+  }, [progress, status]);
+
+  // ── Loading ────────────────────────────────────────────────────────────────
+  if (!hasHydrated) {
+    return (
+      <div className="min-h-screen bg-background text-white flex items-center justify-center">
+        <Loader2 className="w-8 h-8 text-brand animate-spin" />
+      </div>
+    );
+  }
+
+  // ── Job not found ──────────────────────────────────────────────────────────
+  if (!job) {
+    return (
+      <div className="min-h-screen bg-background text-white flex flex-col items-center justify-center gap-6 px-6">
+        <AlertCircle className="w-12 h-12 text-red-400" />
+        <h1 className="text-2xl font-extrabold">Transform job not found</h1>
+        <p className="text-muted-foreground text-sm text-center max-w-sm">
+          This job ID doesn&apos;t exist or has expired. Return to your projects to start a new transformation.
+        </p>
+        <button
+          onClick={() => router.push("/projects")}
+          className="flex items-center gap-2 px-6 py-3 rounded-full bg-brand text-black font-bold text-sm hover:bg-brand-hover transition-all"
+        >
+          <ChevronRight className="w-4 h-4" />
+          Go to Projects
+        </button>
+      </div>
+    );
+  }
+
+  // ── Error state ────────────────────────────────────────────────────────────
+  if (status === "error") {
+    const isUnsupportedFormat = errorMessage?.toLowerCase().includes("format");
+    const isQuotaExceeded = errorMessage?.toLowerCase().includes("quota");
+    const isTimeout = errorMessage?.toLowerCase().includes("timeout");
+
+    return (
+      <div className="min-h-screen bg-background text-white flex flex-col font-sans relative overflow-hidden">
+        <div className="fixed inset-0 pointer-events-none">
+          <div className="absolute top-[-10%] left-1/2 -translate-x-1/2 w-[800px] h-[500px] bg-red-500/5 blur-[120px] rounded-full" />
+        </div>
+
+        <main className="flex-1 flex flex-col items-center justify-center px-6 py-16 relative z-10">
+          <div className="relative mb-10">
+            <div className="absolute inset-0 bg-red-500/20 blur-2xl rounded-full" />
+            <div className="relative w-20 h-20 rounded-full bg-surface border border-red-500/30 flex items-center justify-center">
+              <AlertCircle className="w-9 h-9 text-red-500" />
+            </div>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl font-extrabold text-center mb-3">
+            Transformation Failed
+          </h1>
+
+          {isUnsupportedFormat && (
+            <p className="text-muted-foreground text-center text-sm max-w-md mb-8">
+              This clip format isn&apos;t supported for AI transformation. Try converting to MP4 (H.264) first.
+            </p>
+          )}
+          {isQuotaExceeded && (
+            <p className="text-muted-foreground text-center text-sm max-w-md mb-8">
+              You&apos;ve reached your transformation quota for this billing period. Upgrade your plan to continue.
+            </p>
+          )}
+          {isTimeout && (
+            <p className="text-muted-foreground text-center text-sm max-w-md mb-8">
+              The AI backend timed out. This usually happens with very long clips. Try trimming the clip to under 60 seconds.
+            </p>
+          )}
+          {!isUnsupportedFormat && !isQuotaExceeded && !isTimeout && (
+            <p className="text-muted-foreground text-center text-sm max-w-md mb-8">
+              {errorMessage ?? "An unexpected error occurred. Our team has been notified."}
+            </p>
+          )}
+
+          <div className="flex flex-col sm:flex-row gap-3">
+            <button
+              onClick={() => router.push(`/projects`)}
+              className="flex items-center gap-2 px-6 py-3 rounded-full bg-brand text-black font-bold text-sm hover:bg-brand-hover transition-all"
+            >
+              <Wand2 className="w-4 h-4" />
+              Try Another Style
+            </button>
+            <button
+              onClick={() => router.back()}
+              className="flex items-center gap-2 px-6 py-3 rounded-full border border-white/10 bg-surface hover:bg-input hover:border-white/20 text-gray-300 font-bold text-sm transition-all"
+            >
+              <X className="w-4 h-4" />
+              Go Back
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // ── Complete state ─────────────────────────────────────────────────────────
+  if (status === "complete" && resultUrl) {
+    // Use sourceClipId as a placeholder original — in production this would
+    // be resolved to a pre-signed URL from cloud storage.
+    const originalSrc = `/api/clips/${job.sourceClipId}/stream`;
+
+    return (
+      <div className="min-h-screen bg-background text-white flex flex-col font-sans relative overflow-hidden">
+        <div className="fixed inset-0 pointer-events-none">
+          <div className="absolute top-[-10%] left-1/2 -translate-x-1/2 w-[1000px] h-[600px] bg-brand/5 blur-[120px] rounded-full" />
+        </div>
+
+        <main className="flex-1 flex flex-col items-center px-6 py-16 relative z-10">
+          <div className="w-full max-w-4xl space-y-10">
+            {/* Header */}
+            <div className="flex flex-col items-center text-center gap-4">
+              <div className="relative">
+                <div className="absolute inset-0 bg-green-500/20 blur-2xl rounded-full" />
+                <div className="relative w-16 h-16 rounded-full bg-surface border border-green-500/30 flex items-center justify-center">
+                  <CheckCircle className="w-7 h-7 text-green-500" />
+                </div>
+              </div>
+              <h1 className="text-3xl md:text-4xl font-extrabold">
+                Transformation Complete
+              </h1>
+              <p className="text-muted-foreground text-sm">
+                Your clip has been transformed to{" "}
+                <span className="text-brand font-bold">{styleLabel(style)}</span> style.
+              </p>
+            </div>
+
+            {/* Side-by-side comparison */}
+            <div className="bg-surface border border-white/5 rounded-3xl p-6 md:p-8">
+              <ComparisonPlayer originalSrc={originalSrc} transformedSrc={resultUrl} />
+            </div>
+
+            {/* Action buttons */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <button
+                onClick={() => router.push("/vault")}
+                className="flex flex-col items-center gap-2 px-4 py-4 rounded-2xl bg-brand text-black font-bold text-xs hover:bg-brand-hover transition-all"
+              >
+                <Upload className="w-4 h-4" />
+                Save to Vault
+              </button>
+              <button
+                onClick={() => router.push("/platforms")}
+                className="flex flex-col items-center gap-2 px-4 py-4 rounded-2xl border border-white/10 bg-surface hover:bg-input hover:border-white/20 text-white font-bold text-xs transition-all"
+              >
+                <Sparkles className="w-4 h-4 text-brand" />
+                Post to Platforms
+              </button>
+              <button
+                onClick={() => router.push("/projects")}
+                className="flex flex-col items-center gap-2 px-4 py-4 rounded-2xl border border-white/10 bg-surface hover:bg-input hover:border-white/20 text-white font-bold text-xs transition-all"
+              >
+                <Wand2 className="w-4 h-4 text-brand" />
+                Try Another Style
+              </button>
+              <a
+                href={resultUrl}
+                download
+                className="flex flex-col items-center gap-2 px-4 py-4 rounded-2xl border border-white/10 bg-surface hover:bg-input hover:border-white/20 text-white font-bold text-xs transition-all text-center"
+              >
+                <Download className="w-4 h-4 text-brand" />
+                Download
+              </a>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // ── Processing / Queued state (default) ────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-background text-white flex flex-col font-sans relative overflow-hidden">
+      <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute top-[-10%] left-1/2 -translate-x-1/2 w-[1000px] h-[600px] bg-brand/5 blur-[120px] rounded-full" />
+        <div className="absolute bottom-[-10%] right-[-10%] w-[600px] h-[600px] bg-brand/[0.03] blur-[120px] rounded-full" />
+      </div>
+
+      <main className="flex-1 flex flex-col items-center justify-center px-6 py-16 relative z-10">
+        <div className="w-full max-w-3xl space-y-10">
+          {/* Hero */}
+          <div className="flex flex-col items-center text-center gap-5">
+            <div className="relative">
+              <div className="absolute inset-0 bg-brand/20 blur-2xl rounded-full animate-pulse" />
+              <div className="relative w-20 h-20 rounded-full bg-surface border border-brand/30 flex items-center justify-center">
+                <Wand2 className="w-9 h-9 text-brand" />
+              </div>
+            </div>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-extrabold mb-2">
+                AI Transformation in Progress
+              </h1>
+              <p className="text-muted-foreground text-sm">
+                Applying{" "}
+                <span className="text-brand font-bold">{styleLabel(style)}</span> style to your clip…
+              </p>
+            </div>
+          </div>
+
+          {/* Main card */}
+          <div className="bg-surface border border-white/5 rounded-3xl p-8 space-y-7">
+            {/* Clip thumbnail placeholder */}
+            <div className="flex items-center gap-4">
+              <div className="w-20 h-14 rounded-xl bg-input border border-white/5 flex items-center justify-center shrink-0">
+                {previewUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={previewUrl}
+                    alt="Latest preview frame"
+                    className="w-full h-full object-cover rounded-xl"
+                  />
+                ) : (
+                  <Loader2 className="w-5 h-5 text-muted-foreground animate-spin" />
+                )}
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs font-bold text-white truncate">Clip {job.sourceClipId}</p>
+                <p className="text-[11px] text-muted-foreground mt-0.5">
+                  Style: <span className="text-brand font-semibold">{styleLabel(style)}</span>
+                </p>
+              </div>
+              <div className="ml-auto shrink-0">
+                <span className="flex items-center gap-1.5 text-[11px] font-bold text-brand bg-brand/10 border border-brand/20 px-2.5 py-1 rounded-full">
+                  <RefreshCw className="w-3 h-3 animate-spin" />
+                  {status === "queued" ? "Queued" : "Processing"}
+                </span>
+              </div>
+            </div>
+
+            {/* Progress bar */}
+            <div className="space-y-2">
+              <div className="flex justify-between text-xs font-bold">
+                <span className="text-muted-foreground">Progress</span>
+                <span className="text-brand">{progress}%</span>
+              </div>
+              <div className="relative h-3 w-full bg-input rounded-full overflow-hidden border border-white/5">
+                <div
+                  className="absolute top-0 left-0 h-full bg-brand rounded-full transition-all duration-[1500ms] ease-out shadow-[0_0_12px_rgba(0,255,133,0.4)]"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+
+            {/* ETA */}
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Clock className="w-4 h-4 shrink-0" />
+              <span>ETA: {formatEta(eta)}</span>
+            </div>
+
+            {/* Preview frames */}
+            {previewUrl && (
+              <div className="space-y-2">
+                <p className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+                  Latest Preview Frame
+                </p>
+                <div className="rounded-2xl overflow-hidden border border-white/10 bg-black aspect-video flex items-center justify-center">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={previewUrl}
+                    alt="Preview frame from AI transformation"
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Cancel */}
+          <div className="flex justify-center">
+            <button
+              onClick={() => router.push("/projects")}
+              className="flex items-center gap-2 px-6 py-3 rounded-full border border-white/10 bg-surface hover:bg-input hover:border-white/20 text-gray-300 font-bold text-sm transition-all"
+            >
+              <X className="w-4 h-4" />
+              Cancel
+            </button>
+          </div>
+
+          <p className="text-center text-muted-foreground text-xs leading-relaxed">
+            Closing this window won&apos;t cancel the transformation.{" "}
+            <Link href="/projects" className="text-brand hover:underline">
+              View all projects
+            </Link>
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/api/transform/route.ts
+++ b/app/api/transform/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCsrf } from "@/app/lib/csrf";
+import { applyRateLimit } from "@/app/lib/serverRateLimit";
+import { requireAuth } from "@/app/api/jobs/shared/authGuard";
+import { dispatchJob } from "@/app/lib/aiBackend";
+import { logger } from "@/app/lib/logger";
+import { randomUUID } from "crypto";
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+/** Allowed transform styles sourced from env at startup, with a safe fallback. */
+const ALLOWED_STYLES: string[] = (() => {
+  const raw = process.env.NEXT_PUBLIC_TRANSFORM_STYLES ?? "anime,cinematic,sketch,watercolor";
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+})();
+
+interface TransformRequestBody {
+  clipId: string;
+  style: string;
+  userId?: string;
+}
+
+function validateBody(
+  body: unknown,
+): { valid: true; data: TransformRequestBody } | { valid: false; error: string } {
+  if (!body || typeof body !== "object") {
+    return { valid: false, error: "Request body must be a JSON object." };
+  }
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.clipId !== "string" || !b.clipId.trim()) {
+    return { valid: false, error: "clipId is required and must be a non-empty string." };
+  }
+  if (typeof b.style !== "string" || !ALLOWED_STYLES.includes(b.style.toLowerCase())) {
+    return {
+      valid: false,
+      error: `style must be one of: ${ALLOWED_STYLES.join(", ")}.`,
+    };
+  }
+
+  return {
+    valid: true,
+    data: {
+      clipId: b.clipId.trim(),
+      style: b.style.toLowerCase(),
+      userId: typeof b.userId === "string" ? b.userId : undefined,
+    },
+  };
+}
+
+// ─── POST /api/transform ──────────────────────────────────────────────────────
+
+/**
+ * Create a new AI video transformation job.
+ *
+ * Request body:
+ *   { clipId: string, style: string, userId?: string }
+ *
+ * Response:
+ *   201 { jobId, clipId, style, status: "queued" }
+ *
+ * The job is dispatched to the AI backend immediately. The backend reports
+ * progress via callbacks to /api/jobs/[id]/callback (same flow as clip jobs).
+ */
+export async function POST(request: NextRequest) {
+  // Rate-limit to 20 transform requests per minute per client
+  const rateLimited = await applyRateLimit(request, { limit: 20, windowMs: 60_000 });
+  if (rateLimited) return rateLimited;
+
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId: authenticatedUserId } = authResult;
+
+  // Parse body
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const validation = validateBody(rawBody);
+  if (!validation.valid) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  const { clipId, style } = validation.data;
+  const userId = authenticatedUserId;
+
+  // Build job id and derive the source clip's storage key
+  const jobId = `transform_${randomUUID().replace(/-/g, "")}`;
+  // The source clip key follows the same convention used by uploadFile:
+  // KEY_PREFIX + clipId + extension. We pass the clipId as sourceClipKey
+  // and let the AI backend resolve the full path using its own storage config.
+  const sourceClipKey = `uploads/${clipId}`;
+
+  // Derive callback URL from NEXTAUTH_URL (same approach as jobs/[id]/route.ts)
+  const base =
+    process.env.NEXTAUTH_URL?.replace(/\/$/, "") ??
+    `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const callbackUrl = `${base}/api/jobs/${jobId}/callback`;
+
+  const dispatchResult = await dispatchJob({
+    jobId,
+    userId,
+    objectKey: sourceClipKey,
+    contentType: "video/mp4",
+    filename: `${clipId}.mp4`,
+    callbackUrl,
+    transformStyle: style,
+    sourceClipKey,
+  });
+
+  if (!dispatchResult.dispatched) {
+    logger.warn(
+      `[transform] Dispatch failed for job ${jobId}: ${dispatchResult.reason}. ` +
+        "Job will remain in queued status.",
+    );
+  }
+
+  return NextResponse.json(
+    {
+      jobId,
+      clipId,
+      style,
+      status: "queued",
+      dispatched: dispatchResult.dispatched,
+    },
+    { status: 201 },
+  );
+}

--- a/app/hooks/useTransformStatus.ts
+++ b/app/hooks/useTransformStatus.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { useTransformStore } from "@/app/store/transformStore";
+import type { TransformJob } from "@/app/store/transformStore";
+import { logger } from "@/app/lib/logger";
+
+/** Shape returned by the job status endpoint (reusing the existing /api/jobs/[id] contract). */
+interface JobStatusResponse {
+  progress: number;
+  status: TransformJob["status"];
+  momentsFound?: number;
+  estimatedSecondsRemaining?: number | null;
+  errorMessage?: string;
+  previewUrl?: string;
+  resultUrl?: string;
+}
+
+const POLL_INTERVAL_MS = 3_000;
+const TERMINAL_STATUSES: TransformJob["status"][] = ["complete", "error"];
+
+/**
+ * Poll /api/jobs/[jobId] for transform progress and keep the transformStore in sync.
+ *
+ * Returns a `stopPolling` function so the caller can cancel polling explicitly
+ * (e.g. when the component unmounts or the user navigates away).
+ *
+ * @param jobId  - The transform job id to monitor.
+ * @param enabled - Set to false to prevent polling (default: true).
+ */
+export function useTransformStatus(jobId: string | null, enabled = true) {
+  const { updateJob } = useTransformStore();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const destroyedRef = useRef(false);
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    destroyedRef.current = false;
+    if (!jobId || !enabled) return stopPolling;
+
+    const poll = async () => {
+      if (destroyedRef.current) return;
+      try {
+        const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}`);
+        if (!res.ok) {
+          logger.warn(`[useTransformStatus] Non-OK response for job ${jobId}: ${res.status}`);
+          return;
+        }
+        const data = (await res.json()) as JobStatusResponse;
+
+        updateJob(jobId, {
+          progress: data.progress ?? 0,
+          status: data.status,
+          ...(data.previewUrl ? { previewUrl: data.previewUrl } : {}),
+          ...(data.resultUrl ? { resultUrl: data.resultUrl } : {}),
+          ...(data.errorMessage ? { errorMessage: data.errorMessage } : {}),
+        });
+
+        // Stop polling once a terminal state is reached
+        if (TERMINAL_STATUSES.includes(data.status)) {
+          stopPolling();
+        }
+      } catch (err) {
+        logger.error(
+          `[useTransformStatus] Poll error for job ${jobId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    };
+
+    // Immediate first fetch
+    poll();
+
+    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => {
+      destroyedRef.current = true;
+      stopPolling();
+    };
+  }, [jobId, enabled, updateJob, stopPolling]);
+
+  return { stopPolling };
+}

--- a/app/lib/aiBackend.ts
+++ b/app/lib/aiBackend.ts
@@ -43,6 +43,17 @@ export interface DispatchJobPayload {
    * Format: POST <callbackUrl>  body: JobCallbackPayload
    */
   callbackUrl: string;
+  /**
+   * Optional: the visual style to apply for AI video transformation jobs
+   * (e.g. "anime", "cinematic", "sketch", "watercolor").
+   * Absent for standard clip-extraction jobs.
+   */
+  transformStyle?: string;
+  /**
+   * Optional: the source clip's object key in cloud storage, used when the
+   * job is a style-transfer transformation rather than a raw upload.
+   */
+  sourceClipKey?: string;
 }
 
 /**

--- a/app/lib/cloudStorage.ts
+++ b/app/lib/cloudStorage.ts
@@ -93,6 +93,8 @@ function buildS3Client(): S3Client {
 const BUCKET = () => requireEnv("CLOUD_STORAGE_BUCKET");
 const KEY_PREFIX = process.env.CLOUD_STORAGE_KEY_PREFIX ?? "uploads/";
 const QUARANTINE_PREFIX = process.env.VIRUS_SCAN_QUARANTINE_PREFIX ?? "uploads/quarantine/";
+/** Prefix used for AI-transformed output files, kept separate from raw uploads. */
+export const TRANSFORMS_PREFIX = "transforms/";
 
 // Multipart threshold: files larger than 50 MB use multipart upload.
 const MULTIPART_THRESHOLD = 50 * 1024 * 1024; // 50 MB
@@ -371,4 +373,49 @@ export async function deleteFile(objectKey: string): Promise<void> {
       Key: objectKey,
     }),
   );
+}
+
+/**
+ * Store an AI-transformed video result under the `transforms/` prefix.
+ *
+ * Mirrors uploadFile but uses TRANSFORMS_PREFIX so transform outputs are
+ * stored separately from raw user uploads and can be managed independently
+ * (e.g. different lifecycle policies, cost attribution).
+ *
+ * @param buffer - Transformed video data.
+ * @param jobId  - The transform job id (used as the object key stem).
+ * @param contentType - MIME type of the transformed file.
+ * @returns UploadResult scoped to the transforms/ prefix.
+ */
+export async function uploadTransformResult(
+  buffer: Buffer,
+  jobId: string,
+  contentType: string,
+): Promise<UploadResult> {
+  const client = buildS3Client();
+  const bucket = BUCKET();
+
+  const ext = contentType.includes("mp4") ? "mp4" : "mp4";
+  const objectKey = `${TRANSFORMS_PREFIX}${jobId}.${ext}`;
+
+  if (buffer.length > MULTIPART_THRESHOLD) {
+    await uploadMultipart(client, bucket, objectKey, buffer, contentType);
+  } else {
+    await uploadSinglePart(client, bucket, objectKey, buffer, contentType);
+  }
+
+  const endpoint = process.env.CLOUD_STORAGE_ENDPOINT;
+  const region = process.env.CLOUD_STORAGE_REGION ?? "us-east-1";
+  const url = endpoint
+    ? `${endpoint.replace(/\/$/, "")}/${bucket}/${objectKey}`
+    : `https://${bucket}.s3.${region}.amazonaws.com/${objectKey}`;
+
+  return {
+    jobId,
+    objectKey,
+    url,
+    filename: `${jobId}.${ext}`,
+    size: buffer.length,
+    contentType,
+  };
 }

--- a/app/recovery/page.tsx
+++ b/app/recovery/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -21,6 +21,7 @@ import {
   Users,
   ChevronRight,
   RefreshCw,
+  Upload,
 } from "lucide-react";
 
 export default function RecoveryPage() {
@@ -28,13 +29,18 @@ export default function RecoveryPage() {
   const { setUser } = useAuth();
   const { importStellarKey, connectStellar } = useWallet();
 
-  const [activeTab, setActiveTab] = useState<"mnemonic" | "social">("mnemonic");
+  const [activeTab, setActiveTab] = useState<"mnemonic" | "social" | "encrypted">("mnemonic");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
   // Mnemonic State
   const [mnemonicInput, setMnemonicInput] = useState("");
+
+  // Encrypted Backup State
+  const [encryptedFile, setEncryptedFile] = useState<File | null>(null);
+  const [encryptedPassword, setEncryptedPassword] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Social Recovery State
   const [socialEmail, setSocialEmail] = useState("");
@@ -240,6 +246,65 @@ export default function RecoveryPage() {
     }
   };
 
+  const handleEncryptedBackupRecovery = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+
+    if (!encryptedFile) {
+      setError("Please select a backup file.");
+      return;
+    }
+    if (!encryptedPassword) {
+      setError("Please enter your backup password.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const text = await encryptedFile.text();
+      const backup = JSON.parse(text) as { ciphertext?: string; version?: number };
+      if (!backup.ciphertext) {
+        throw new Error("Invalid backup file format. Expected a clipcash-wallet-backup.enc.json file.");
+      }
+
+      const decrypted = await decryptWithPassword(backup.ciphertext, encryptedPassword);
+
+      if (decrypted.startsWith("S") && decrypted.length === 56) {
+        await importStellarKey(decrypted);
+      } else {
+        const wallet = await restoreWalletFromMnemonic(decrypted);
+        await importStellarKey(wallet.secretKey);
+        const stored = await secureStorage.getItem("clipcash_wallet");
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          parsed.stellarMnemonic = decrypted;
+          await secureStorage.setItem("clipcash_wallet", JSON.stringify(parsed));
+        }
+      }
+
+      const loggedInUser = {
+        id: "recovered-user-id",
+        email: "",
+        username: "recovered_user",
+        onboardingStep: 3,
+        name: "Recovered User",
+      };
+      setUser(loggedInUser);
+      setSuccess("Wallet restored from encrypted backup! Redirecting to Dashboard…");
+      setTimeout(() => router.push("/dashboard"), 2000);
+    } catch (err: any) {
+      const msg = err?.message ?? "";
+      if (msg.includes("decrypt") || msg.includes("key") || msg.toLowerCase().includes("operation")) {
+        setError("Decryption failed. Check your password and try again.");
+      } else {
+        setError(msg || "Failed to restore from backup.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-[#030605] text-white flex flex-col font-sans relative overflow-hidden">
       {/* Background glow effects */}
@@ -271,7 +336,7 @@ export default function RecoveryPage() {
           </div>
 
           {/* Toggle Tabs */}
-          <div className="grid grid-cols-2 gap-1 bg-[#121915] p-1 rounded-xl mb-6">
+          <div className="grid grid-cols-3 gap-1 bg-[#121915] p-1 rounded-xl mb-6">
             <button
               onClick={() => {
                 setActiveTab("mnemonic");
@@ -285,6 +350,20 @@ export default function RecoveryPage() {
               }`}
             >
               Mnemonic Phrase
+            </button>
+            <button
+              onClick={() => {
+                setActiveTab("encrypted");
+                setError("");
+                setSuccess("");
+              }}
+              className={`py-2 rounded-lg text-xs font-bold transition-all cursor-pointer ${
+                activeTab === "encrypted"
+                  ? "bg-brand text-black shadow-lg"
+                  : "text-muted-foreground hover:text-white"
+              }`}
+            >
+              Encrypted Backup
             </button>
             <button
               onClick={() => {
@@ -357,7 +436,76 @@ export default function RecoveryPage() {
             </form>
           )}
 
-          {/* Tab 2: Social Recovery Form */}
+          {/* Tab 2: Encrypted Backup Form */}
+          {activeTab === "encrypted" && (
+            <form onSubmit={handleEncryptedBackupRecovery} className="space-y-5">
+              <div className="space-y-2">
+                <label className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+                  Backup File
+                </label>
+                <div
+                  onClick={() => fileInputRef.current?.click()}
+                  className="w-full bg-[#111613] border border-dashed border-white/10 hover:border-brand/40 rounded-xl px-4 py-5 text-xs text-muted-foreground flex flex-col items-center gap-2 cursor-pointer transition-colors"
+                >
+                  <Upload className="w-5 h-5 text-brand" />
+                  {encryptedFile ? (
+                    <span className="text-white font-medium">{encryptedFile.name}</span>
+                  ) : (
+                    <span>Click to select <strong className="text-white">clipcash-wallet-backup.enc.json</strong></span>
+                  )}
+                </div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json,application/json"
+                  className="hidden"
+                  onChange={(e) => setEncryptedFile(e.target.files?.[0] ?? null)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="encrypted-password" className="block text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+                  Backup Password
+                </label>
+                <div className="relative">
+                  <input
+                    id="encrypted-password"
+                    type="password"
+                    placeholder="Password set during export"
+                    value={encryptedPassword}
+                    onChange={(e) => setEncryptedPassword(e.target.value)}
+                    className="w-full bg-[#111613] border border-white/5 text-white focus:border-brand/40 rounded-xl pl-10 pr-4 py-3.5 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition-colors"
+                    autoComplete="current-password"
+                  />
+                  <Lock className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                </div>
+              </div>
+
+              <div className="bg-white/[0.01] border border-white/5 rounded-xl p-3.5 flex gap-2.5">
+                <Key className="w-4 h-4 text-brand shrink-0 mt-0.5" />
+                <p className="text-[10px] text-muted-foreground leading-normal">
+                  Decryption is performed entirely client-side using AES-GCM. Your password never leaves your device.
+                </p>
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading || !encryptedFile || !encryptedPassword}
+                className="w-full py-4 rounded-xl bg-brand hover:bg-brand-hover text-black font-extrabold text-[14px] flex items-center justify-center gap-2 transition-all active:scale-[0.98] cursor-pointer disabled:opacity-40"
+              >
+                {loading ? (
+                  <><Loader2 className="w-4 h-4 animate-spin" /> Decrypting Backup…</>
+                ) : (
+                  <>
+                    <span>Restore from Backup</span>
+                    <ChevronRight className="w-4 h-4" />
+                  </>
+                )}
+              </button>
+            </form>
+          )}
+
+          {/* Tab 3: Social Recovery Form */}
           {activeTab === "social" && (
             <div className="space-y-5">
               {!sessionId ? (

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -68,3 +68,14 @@ export type {
   EarningsState,
   EarningsActions,
 } from "./types";
+
+// Transform
+export {
+  useTransformStore,
+  selectAllJobs,
+  selectJobById,
+  selectActiveJob,
+  selectTransformHasHydrated,
+} from "./transformStore";
+
+export type { TransformJob, TransformStatus } from "./transformStore";

--- a/app/store/transformStore.ts
+++ b/app/store/transformStore.ts
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * transformStore.ts — Zustand store for AI video transformation jobs.
+ *
+ * Tracks all in-flight and completed transformation jobs. State is persisted
+ * to secureStorage so users can resume monitoring after a page reload.
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { secureStorage } from "@/app/lib/secureStorage";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TransformStatus = "queued" | "processing" | "complete" | "error";
+
+/**
+ * A single AI video transformation job.
+ */
+export interface TransformJob {
+  /** Stable job id assigned at creation time. */
+  id: string;
+  /** The source clip being transformed. */
+  sourceClipId: string;
+  /** The visual style applied to this transformation. */
+  style: string;
+  /** Current lifecycle status of the transformation. */
+  status: TransformStatus;
+  /** Completion percentage 0–100. */
+  progress: number;
+  /** URL of the final transformed video (set on completion). */
+  resultUrl: string | null;
+  /** ISO timestamp when the job was created. */
+  createdAt: string;
+  /** URL of the latest preview frame (set as frames are generated). */
+  previewUrl: string | null;
+  /** Human-readable error message if status === "error". */
+  errorMessage?: string;
+}
+
+// ─── Store shape ──────────────────────────────────────────────────────────────
+
+interface TransformState {
+  /** All known jobs keyed by their id. */
+  jobs: Record<string, TransformJob>;
+  /** The job currently being monitored in the UI. */
+  activeJobId: string | null;
+  /** True once secureStorage rehydration has completed. */
+  hasHydrated: boolean;
+}
+
+interface TransformActions {
+  /** Create a new job record locally and return its id. */
+  addJob: (job: TransformJob) => void;
+  /** Apply a partial update to an existing job. */
+  updateJob: (id: string, patch: Partial<TransformJob>) => void;
+  /** Remove a job from the store. */
+  removeJob: (id: string) => void;
+  /** Set the job that the transform progress page is monitoring. */
+  setActiveJobId: (id: string | null) => void;
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+export const useTransformStore = create<TransformState & TransformActions>()(
+  persist(
+    (set) => ({
+      jobs: {},
+      activeJobId: null,
+      hasHydrated: false,
+
+      addJob: (job) =>
+        set((state) => ({
+          jobs: { ...state.jobs, [job.id]: job },
+        })),
+
+      updateJob: (id, patch) =>
+        set((state) => {
+          const existing = state.jobs[id];
+          if (!existing) return state;
+          return {
+            jobs: { ...state.jobs, [id]: { ...existing, ...patch } },
+          };
+        }),
+
+      removeJob: (id) =>
+        set((state) => {
+          const { [id]: _removed, ...rest } = state.jobs;
+          return { jobs: rest };
+        }),
+
+      setActiveJobId: (id) => set({ activeJobId: id }),
+    }),
+    {
+      name: "clips_transform_state",
+      storage: createJSONStorage(() => secureStorage),
+      partialize: (state) => ({
+        jobs: state.jobs,
+        activeJobId: state.activeJobId,
+      }),
+      skipHydration: true,
+      onRehydrateStorage: () => (_state, error) => {
+        if (!error) {
+          useTransformStore.setState({ hasHydrated: true });
+        }
+      },
+    },
+  ),
+);
+
+if (typeof window !== "undefined") {
+  useTransformStore.persist.rehydrate();
+}
+
+// ─── Selectors ────────────────────────────────────────────────────────────────
+
+/** Select all transform jobs as an array, sorted newest-first. */
+export const selectAllJobs = (s: TransformState & TransformActions): TransformJob[] =>
+  Object.values(s.jobs).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+/** Select a single job by id. */
+export const selectJobById =
+  (id: string) =>
+  (s: TransformState & TransformActions): TransformJob | undefined =>
+    s.jobs[id];
+
+/** Select the currently active job (the one being monitored). */
+export const selectActiveJob = (s: TransformState & TransformActions): TransformJob | undefined =>
+  s.activeJobId ? s.jobs[s.activeJobId] : undefined;
+
+/** True once secureStorage has resolved. */
+export const selectTransformHasHydrated = (s: TransformState & TransformActions): boolean =>
+  s.hasHydrated;

--- a/components/auth/AuthProvider.tsx
+++ b/components/auth/AuthProvider.tsx
@@ -2,10 +2,12 @@
 
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
-import { useRouter, usePathname } from "next/navigation";
 import { persistClipcashUser, loadClipcashUser, clearClipcashUser } from "@/app/lib/authUser";
 
-const PUBLIC_ROUTES = ["/", "/login", "/privacy", "/terms", "/status", "/cookies"];
+// Route protection is handled server-side by middleware.ts via NextAuth JWT.
+// The AuthProvider no longer performs client-side redirects, which previously
+// caused dashboard content to flash for one frame before the redirect fired.
+// See: middleware.ts
 
 export interface AuthUser {
   id: string;
@@ -27,8 +29,6 @@ AuthContext.displayName = "AuthContext";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession();
-  const router = useRouter();
-  const pathname = usePathname();
 
   const [user, setUserState] = useState<AuthUser | null>(null);
   const [storageLoaded, setStorageLoaded] = useState(false);
@@ -67,18 +67,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       });
     }
   }, [status, session]);
-
-  // Route guard
-  useEffect(() => {
-    if (isLoading) return;
-    if (status === "authenticated") return;
-    const isPublic = PUBLIC_ROUTES.some(
-      (r) => pathname === r || pathname.startsWith(r + "/")
-    );
-    if (!user && !isPublic) {
-      router.push("/login");
-    }
-  }, [user, isLoading, status, pathname, router]);
 
   const setUser = useCallback((newUser: AuthUser) => {
     setUserState(newUser);


### PR DESCRIPTION
…& progress page

Closes #690
Closes #692 
Closes #694 
Closes #697

## #690 — [SEC] Next.js Middleware for Route Protection

- middleware.ts already implements edge-based JWT route protection via NextAuth's withAuth helper, covering all PROTECTED_ROUTES and redirecting authenticated users away from /login and /signup.
- Removed the redundant client-side route guard useEffect from components/auth/AuthProvider.tsx that caused a one-frame dashboard flash before redirect. AuthProvider now handles only session sync and user state; all hard redirects happen at the edge before any page content is served.

## #692 — [FEAT] Encrypted Secret Key Export in Settings

- Replaced the no-op 'Encrypted export will be available in the next step' toast with a full export modal (app/(dashboard)/settings/page.tsx).
- Modal requires a password (min 8 chars) + confirmation, encrypts the secret key via encryptWithPassword (AES-GCM / PBKDF2) from cryptoUtils.ts, and downloads clipcash-wallet-backup.enc.json containing the ciphertext plus _instructions and createdAt metadata fields.
- Reveal button now auto-hides the key and clears the clipboard after 15s.
- Added 'Encrypted Backup' tab to app/recovery/page.tsx: users upload their .enc.json file, enter the backup password, and the key is decrypted client-side and imported via importStellarKey — exactly mirroring the mnemonic recovery flow.

## #694 — [FEAT] AI Video Transformation — Core Architecture

- Created app/store/transformStore.ts: Zustand store persisted to secureStorage with jobs: Record<string, TransformJob>, activeJobId, hasHydrated. TransformJob carries id, sourceClipId, style, status, progress, resultUrl, createdAt, previewUrl, errorMessage.
- Extended DispatchJobPayload in app/lib/aiBackend.ts with optional transformStyle?: string and sourceClipKey?: string fields.
- Created POST /api/transform route: validates clipId + style against NEXT_PUBLIC_TRANSFORM_STYLES env var, assigns a transform_ prefixed job id, dispatches to AI backend with the transform fields, returns 201 with { jobId, clipId, style, status: 'queued' }.
- Added TRANSFORMS_PREFIX = 'transforms/' constant and uploadTransformResult() helper to app/lib/cloudStorage.ts so transform outputs are stored under a separate prefix from raw uploads.
- Exported transform store and types from app/store/index.ts barrel.
- Added NEXT_PUBLIC_TRANSFORM_STYLES=anime,cinematic,sketch,watercolor to .env.example.

## #697 — [FEAT] AI Video Transformation — Transform Progress Page

- Created app/hooks/useTransformStatus.ts: polls /api/jobs/[id] every 3s, syncs progress/status/previewUrl/resultUrl into transformStore, stops automatically on complete/error.
- Created app/(dashboard)/transform/[id]/page.tsx with four render states:
  - Loading: spinner while secureStorage rehydrates.
  - Not found: error UI with link back to /projects.
  - Processing/Queued: live progress bar, ETA calculation from progress rate, clip thumbnail, style badge, preview frame when available.
  - Complete: side-by-side ComparisonPlayer (original vs transformed) with play/pause sync, and four action buttons (Save to Vault, Post to Platforms, Try Another Style, Download).
  - Error: contextual messages for unsupported format, quota exceeded, and AI backend timeout error codes.