### PR TITLE
fixed frontend issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,30 @@ NEXT_PUBLIC_ANALYTICS_PROVIDER=none
 
 # Custom Analytics Endpoint (if using custom)
 # NEXT_PUBLIC_ANALYTICS_ENDPOINT=https://your-analytics-api.com/events
+
+# ─── OAuth Providers ──────────────────────────────────────────────────────────
+# NextAuth secret (generate with: openssl rand -base64 32)
+NEXTAUTH_SECRET=your-nextauth-secret
+NEXTAUTH_URL=http://localhost:3000
+
+# Google / YouTube OAuth (https://console.cloud.google.com/)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Apple Sign In (https://developer.apple.com/)
+APPLE_ID=
+APPLE_TEAM_ID=
+APPLE_PRIVATE_KEY=
+APPLE_KEY_ID=
+
+# Twitter / X OAuth 2.0 (https://developer.twitter.com/)
+TWITTER_CLIENT_ID=
+TWITTER_CLIENT_SECRET=
+
+# Instagram OAuth (https://developers.facebook.com/)
+INSTAGRAM_CLIENT_ID=
+INSTAGRAM_CLIENT_SECRET=
+
+# TikTok OAuth (https://developers.tiktok.com/)
+TIKTOK_CLIENT_KEY=
+TIKTOK_CLIENT_SECRET=

--- a/clips-frontend/app/api/clips/route.ts
+++ b/clips-frontend/app/api/clips/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server";
+import type { Clip } from "@/app/lib/types/clip";
+
+/**
+ * In-memory clip store — same no-database pattern used by the rest of the app.
+ * Pre-seeded with representative data including clips that already have
+ * AI transformations attached.
+ */
+export const clipsStore: Clip[] = [
+  {
+    id: "clip-001",
+    title: "Epic Gaming Moment - Triple Kill",
+    thumbnail: "https://images.unsplash.com/photo-1542751371-adc38448a05e?w=400&h=400&fit=crop",
+    videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+    duration: "0:45",
+    aiScore: 95,
+    status: "ready_to_mint",
+    rarity: "epic",
+    transformations: [
+      {
+        style: "anime",
+        styleLabel: "Anime",
+        resultUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        jobId: "job_anime_001",
+        createdAt: "2025-06-10T14:22:00Z",
+      },
+      {
+        style: "neon-noir",
+        styleLabel: "Neon Noir",
+        resultUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        jobId: "job_neon_001",
+        createdAt: "2025-06-12T09:05:00Z",
+      },
+    ],
+  },
+  {
+    id: "clip-002",
+    title: "Funny Cat Compilation",
+    thumbnail: "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=400&h=400&fit=crop",
+    duration: "1:30",
+    aiScore: 88,
+    status: "queue",
+    rarity: "rare",
+    queuePosition: 5,
+    transformations: [
+      {
+        style: "watercolor",
+        styleLabel: "Watercolor",
+        resultUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        jobId: "job_wc_001",
+        createdAt: "2025-06-15T11:00:00Z",
+      },
+    ],
+  },
+  {
+    id: "clip-003",
+    title: "Tutorial: How to Code",
+    thumbnail: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=400&h=400&fit=crop",
+    duration: "2:15",
+    aiScore: 92,
+    status: "minted",
+    rarity: "legendary",
+    floorPrice: 0.5,
+    currentValue: 0.75,
+    mintedDate: "2024-01-15",
+    transformations: [],
+  },
+  {
+    id: "clip-004",
+    title: "Daily Vlog Entry",
+    thumbnail: "https://images.unsplash.com/photo-1492691527719-9d1e07e534b4?w=400&h=400&fit=crop",
+    duration: "0:30",
+    aiScore: 75,
+    status: "ready_to_mint",
+    rarity: "common",
+    transformations: [],
+  },
+  {
+    id: "clip-005",
+    title: "Travel Vlog - Tokyo",
+    thumbnail: "https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=400&h=400&fit=crop",
+    duration: "3:00",
+    aiScore: 85,
+    status: "ready_to_mint",
+    rarity: "uncommon",
+    transformations: [
+      {
+        style: "cinematic",
+        styleLabel: "Cinematic",
+        resultUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        jobId: "job_cin_001",
+        createdAt: "2025-06-18T16:30:00Z",
+      },
+    ],
+  },
+  {
+    id: "clip-006",
+    title: "Sports Highlight - Amazing Goal",
+    thumbnail: "https://images.unsplash.com/photo-1579952363873-27f3bade9f55?w=400&h=400&fit=crop",
+    duration: "0:15",
+    aiScore: 98,
+    status: "minted",
+    rarity: "legendary",
+    floorPrice: 1.2,
+    currentValue: 1.5,
+    mintedDate: "2024-02-20",
+    transformations: [
+      {
+        style: "retro-vhs",
+        styleLabel: "Retro VHS",
+        resultUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        jobId: "job_vhs_001",
+        createdAt: "2025-05-30T08:15:00Z",
+      },
+    ],
+  },
+  {
+    id: "clip-007",
+    title: "Music Cover - Acoustic",
+    thumbnail: "https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?w=400&h=400&fit=crop",
+    duration: "0:30",
+    aiScore: 90,
+    status: "minted",
+    rarity: "rare",
+    floorPrice: 0.3,
+    currentValue: 0.25,
+    mintedDate: "2024-03-10",
+    transformations: [],
+  },
+  {
+    id: "clip-008",
+    title: "Cooking Tutorial",
+    thumbnail: "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=400&h=400&fit=crop",
+    duration: "5:00",
+    aiScore: 82,
+    status: "queue",
+    rarity: "uncommon",
+    queuePosition: 42,
+    transformations: [
+      {
+        style: "sketch",
+        styleLabel: "Sketch",
+        resultUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        jobId: "job_sketch_001",
+        createdAt: "2025-06-20T13:45:00Z",
+      },
+    ],
+  },
+];
+
+/**
+ * GET /api/clips
+ *
+ * Returns all clips with their full transformation history.
+ * Accepts an optional `?status=ready_to_mint|queue|minted` query param.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const statusFilter = searchParams.get("status") as Clip["status"] | null;
+
+  const clips = statusFilter
+    ? clipsStore.filter((c) => c.status === statusFilter)
+    : clipsStore;
+
+  return NextResponse.json({ clips });
+}

--- a/clips-frontend/app/api/platforms/connections/route.ts
+++ b/clips-frontend/app/api/platforms/connections/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/lib/auth";
+import {
+  getConnections,
+  deleteConnection,
+  type SocialPlatform,
+} from "@/app/lib/platformConnections";
+
+/**
+ * GET /api/platforms/connections
+ *
+ * Returns all platform connections for the authenticated user.
+ * Response shape:
+ *   { connections: PlatformConnection[] }
+ */
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Use email as the stable user identifier since no database user ID exists yet.
+  const userId = session.user.email;
+  const connections = getConnections(userId);
+
+  // Strip sensitive token fields before sending to the client.
+  const safeConnections = connections.map(({ accessToken, refreshToken, ...rest }) => rest);
+
+  return NextResponse.json({ connections: safeConnections });
+}
+
+/**
+ * DELETE /api/platforms/connections?platform=tiktok
+ *
+ * Removes a specific platform connection for the authenticated user.
+ * Response shape:
+ *   { success: true } | { error: string }
+ */
+export async function DELETE(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const platform = searchParams.get("platform") as SocialPlatform | null;
+
+  const validPlatforms: SocialPlatform[] = [
+    "google",
+    "apple",
+    "tiktok",
+    "youtube",
+    "instagram",
+    "twitter",
+  ];
+
+  if (!platform || !validPlatforms.includes(platform)) {
+    return NextResponse.json(
+      {
+        error: `Invalid or missing platform. Must be one of: ${validPlatforms.join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  const userId = session.user.email;
+  const deleted = deleteConnection(userId, platform);
+
+  if (!deleted) {
+    return NextResponse.json(
+      { error: `No connection found for platform "${platform}"` },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/clips-frontend/app/api/transform/route.ts
+++ b/clips-frontend/app/api/transform/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/lib/auth";
+import { consumeQuota, getRemainingQuota, type Plan } from "@/app/lib/transformQuota";
+
+/**
+ * Request body shape for POST /api/transform
+ */
+interface TransformRequest {
+  clipId: string;
+  style: string;
+}
+
+/**
+ * POST /api/transform
+ *
+ * Checks the user's monthly transform quota before dispatching the job.
+ *
+ * Responses:
+ *   202  { jobId, quotaRemaining }          — job accepted
+ *   400  { error: "..." }                   — bad request
+ *   401  { error: "Unauthorized" }          — not signed in
+ *   429  { code: "QUOTA_EXCEEDED", resetAt} — monthly limit hit
+ */
+export async function POST(request: NextRequest) {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Use email as the stable user identifier (no DB user ID in this project).
+  const userId = session.user.email;
+
+  // Derive plan from the session. The session callback in auth.ts stores it
+  // on session.user — fall back to "free" if missing.
+  const plan = ((session.user as any).plan ?? "free") as Plan;
+
+  // ── Parse body ────────────────────────────────────────────────────────────
+  let body: Partial<TransformRequest>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const { clipId, style } = body;
+
+  if (!clipId || typeof clipId !== "string") {
+    return NextResponse.json(
+      { error: "clipId is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (!style || typeof style !== "string") {
+    return NextResponse.json(
+      { error: "style is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const VALID_STYLES = [
+    "anime",
+    "cinematic",
+    "sketch",
+    "watercolor",
+    "retro-vhs",
+    "neon-noir",
+  ];
+
+  if (!VALID_STYLES.includes(style)) {
+    return NextResponse.json(
+      {
+        error: `Unknown style "${style}". Valid styles: ${VALID_STYLES.join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  // ── Quota check ───────────────────────────────────────────────────────────
+  const result = consumeQuota(userId, plan);
+
+  if (!result.allowed) {
+    return NextResponse.json(
+      {
+        code: "QUOTA_EXCEEDED",
+        error:
+          "You have reached your monthly transformation limit. Upgrade your plan to continue.",
+        resetAt: result.resetAt,
+        upgradePath: "/settings?tab=billing",
+      },
+      { status: 429 }
+    );
+  }
+
+  // ── Dispatch job (simulated) ───────────────────────────────────────────────
+  // In production this would enqueue a background job (e.g. via a queue
+  // service) and return the job ID immediately.
+  const jobId = `job_${style}_${Date.now()}_${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
+
+  return NextResponse.json(
+    {
+      jobId,
+      clipId,
+      style,
+      status: "queued",
+      quotaRemaining: result.remaining,
+    },
+    { status: 202 }
+  );
+}
+
+/**
+ * GET /api/transform
+ *
+ * Returns the current quota status for the authenticated user without
+ * consuming any credits — used by the StylePicker to display the counter.
+ */
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.email;
+  const plan = ((session.user as any).plan ?? "free") as Plan;
+  const remaining = getRemainingQuota(userId, plan);
+
+  // Import here to avoid a circular dep with transformQuota
+  const { getQuota, PLAN_LIMITS } = await import("@/app/lib/transformQuota");
+  const record = getQuota(userId, plan);
+
+  return NextResponse.json({
+    plan,
+    quotaRemaining: remaining === Infinity ? null : remaining,
+    quotaLimit: PLAN_LIMITS[plan] === Infinity ? null : PLAN_LIMITS[plan],
+    resetAt: record.resetAt,
+    unlimited: plan === "enterprise",
+  });
+}

--- a/clips-frontend/app/api/transform/styles/route.ts
+++ b/clips-frontend/app/api/transform/styles/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+
+export interface TransformStyle {
+  id: string;
+  name: string;
+  /** Public URL (or data URI) for the before thumbnail */
+  thumbnailBefore: string;
+  /** Public URL (or data URI) for the after thumbnail */
+  thumbnailAfter: string;
+  /** Estimated processing time in seconds */
+  avgDurationSeconds: number;
+  /** Short description shown on the card */
+  description: string;
+  /** Accent colour used for the selected-state ring and badge */
+  accentColor: string;
+}
+
+/** V1 style presets */
+const STYLES: TransformStyle[] = [
+  {
+    id: "anime",
+    name: "Anime",
+    thumbnailBefore: "/thumbnails/anime-before.jpg",
+    thumbnailAfter: "/thumbnails/anime-after.jpg",
+    avgDurationSeconds: 45,
+    description: "Vivid cel-shading and bold outlines",
+    accentColor: "#FF6B9D",
+  },
+  {
+    id: "cinematic",
+    name: "Cinematic",
+    thumbnailBefore: "/thumbnails/cinematic-before.jpg",
+    thumbnailAfter: "/thumbnails/cinematic-after.jpg",
+    avgDurationSeconds: 30,
+    description: "Film-grade colour grading & letterbox",
+    accentColor: "#E2B04A",
+  },
+  {
+    id: "sketch",
+    name: "Sketch",
+    thumbnailBefore: "/thumbnails/sketch-before.jpg",
+    thumbnailAfter: "/thumbnails/sketch-after.jpg",
+    avgDurationSeconds: 25,
+    description: "Hand-drawn pencil & charcoal look",
+    accentColor: "#A0AEC0",
+  },
+  {
+    id: "watercolor",
+    name: "Watercolor",
+    thumbnailBefore: "/thumbnails/watercolor-before.jpg",
+    thumbnailAfter: "/thumbnails/watercolor-after.jpg",
+    avgDurationSeconds: 50,
+    description: "Soft pigment bleeds on textured paper",
+    accentColor: "#76C7F0",
+  },
+  {
+    id: "retro-vhs",
+    name: "Retro VHS",
+    thumbnailBefore: "/thumbnails/retro-vhs-before.jpg",
+    thumbnailAfter: "/thumbnails/retro-vhs-after.jpg",
+    avgDurationSeconds: 20,
+    description: "80s scan lines, glitch & chromatic aberration",
+    accentColor: "#00E58F",
+  },
+  {
+    id: "neon-noir",
+    name: "Neon Noir",
+    thumbnailBefore: "/thumbnails/neon-noir-before.jpg",
+    thumbnailAfter: "/thumbnails/neon-noir-after.jpg",
+    avgDurationSeconds: 40,
+    description: "Rain-soaked streets with cyberpunk glow",
+    accentColor: "#9D4EDD",
+  },
+];
+
+/**
+ * GET /api/transform/styles
+ *
+ * Returns the list of available AI transformation style presets.
+ */
+export async function GET() {
+  return NextResponse.json({ styles: STYLES });
+}

--- a/clips-frontend/app/lib/auth.ts
+++ b/clips-frontend/app/lib/auth.ts
@@ -1,12 +1,33 @@
 import { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import AppleProvider from "next-auth/providers/apple";
+import { upsertConnection, type SocialPlatform } from "@/app/lib/platformConnections";
+
+/**
+ * Map a NextAuth provider ID to our internal SocialPlatform type.
+ */
+function toSocialPlatform(providerId: string): SocialPlatform | null {
+  const map: Record<string, SocialPlatform> = {
+    google: "google",
+    apple: "apple",
+    tiktok: "tiktok",
+    twitter: "twitter",
+    instagram: "instagram",
+  };
+  return map[providerId] ?? null;
+}
 
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      authorization: {
+        params: {
+          scope:
+            "openid email profile https://www.googleapis.com/auth/youtube.readonly",
+        },
+      },
     }),
     AppleProvider({
       clientId: process.env.APPLE_ID!,
@@ -17,23 +38,130 @@ export const authOptions: NextAuthOptions = {
         keyId: process.env.APPLE_KEY_ID!,
       } as any,
     }),
+    // TikTok uses a custom provider (not in next-auth built-ins)
+    {
+      id: "tiktok",
+      name: "TikTok",
+      type: "oauth",
+      authorization: {
+        url: "https://www.tiktok.com/v2/auth/authorize/",
+        params: {
+          client_key: process.env.TIKTOK_CLIENT_KEY,
+          scope: "user.info.basic,video.list",
+          response_type: "code",
+        },
+      },
+      token: "https://open.tiktokapis.com/v2/oauth/token/",
+      userinfo: "https://open.tiktokapis.com/v2/user/info/",
+      profile(profile: any) {
+        return {
+          id: profile.data.user.open_id,
+          name: profile.data.user.display_name,
+          image: profile.data.user.avatar_url,
+        };
+      },
+      clientId: process.env.TIKTOK_CLIENT_KEY,
+      clientSecret: process.env.TIKTOK_CLIENT_SECRET,
+    } as any,
+    // Twitter / X OAuth 2.0
+    {
+      id: "twitter",
+      name: "X / Twitter",
+      type: "oauth",
+      version: "2.0",
+      authorization: {
+        url: "https://twitter.com/i/oauth2/authorize",
+        params: {
+          scope: "tweet.read users.read offline.access",
+          response_type: "code",
+          code_challenge_method: "S256",
+        },
+      },
+      token: "https://api.twitter.com/2/oauth2/token",
+      userinfo: "https://api.twitter.com/2/users/me",
+      profile(profile: any) {
+        return {
+          id: profile.data.id,
+          name: profile.data.name,
+          image: profile.data.profile_image_url ?? null,
+        };
+      },
+      clientId: process.env.TWITTER_CLIENT_ID,
+      clientSecret: process.env.TWITTER_CLIENT_SECRET,
+    } as any,
+    // Instagram OAuth
+    {
+      id: "instagram",
+      name: "Instagram",
+      type: "oauth",
+      authorization: {
+        url: "https://api.instagram.com/oauth/authorize",
+        params: {
+          scope: "user_profile,user_media",
+          response_type: "code",
+        },
+      },
+      token: "https://api.instagram.com/oauth/access_token",
+      userinfo: "https://graph.instagram.com/me?fields=id,username",
+      profile(profile: any) {
+        return {
+          id: profile.id,
+          name: profile.username,
+          image: null,
+        };
+      },
+      clientId: process.env.INSTAGRAM_CLIENT_ID,
+      clientSecret: process.env.INSTAGRAM_CLIENT_SECRET,
+    } as any,
   ],
+
   callbacks: {
+    /**
+     * Persist OAuth tokens in the JWT and upsert the platform_connections
+     * record on every actual sign-in (account is only present then).
+     */
     async jwt({ token, account, profile }) {
       if (account) {
-        token.accessToken = account.access_token;
+        token.accessToken = account.access_token ?? null;
+        token.refreshToken = account.refresh_token ?? null;
+        token.provider = account.provider;
+
+        // Upsert platform connection whenever a user signs in via OAuth.
+        const platform = toSocialPlatform(account.provider);
+        if (platform && token.email) {
+          const username =
+            (profile as any)?.name ??
+            (profile as any)?.display_name ??
+            (profile as any)?.login ??
+            null;
+
+          upsertConnection({
+            userId: token.email as string,
+            platform,
+            accessToken: account.access_token ?? null,
+            refreshToken: account.refresh_token ?? null,
+            username,
+            connectedAt: new Date().toISOString(),
+          });
+        }
       }
       return token;
     },
+
     async session({ session, token }) {
-      // Assuming the API returns user data including onboardingStep
-      // For now, mock it
       if (session.user) {
-        (session.user as any).onboardingStep = session.user.email?.includes("new") ? 1 : 3; // Mock logic
+        (session.user as any).provider = token.provider ?? null;
+        (session.user as any).accessToken = token.accessToken;
+        // Assuming the API returns user data including onboardingStep
+        // For now, mock it
+        (session.user as any).onboardingStep = session.user.email?.includes("new")
+          ? 1
+          : 3; // Mock logic
       }
       return session;
     },
   },
+
   pages: {
     signIn: "/login",
     error: "/login",

--- a/clips-frontend/app/lib/platformConnections.ts
+++ b/clips-frontend/app/lib/platformConnections.ts
@@ -1,0 +1,59 @@
+/**
+ * In-memory platform connections store.
+ *
+ * Mirrors the pattern used elsewhere in the project (e.g. jobStore in
+ * app/api/jobs/[id]/route.ts) — no external database adapter is present,
+ * so connections live in-process and are cleared on server restart.
+ *
+ * Schema mirrors the spec requirement:
+ *   platform_connections (userId, platform, accessToken, refreshToken, username, connectedAt)
+ */
+
+export type SocialPlatform = "google" | "apple" | "tiktok" | "youtube" | "instagram" | "twitter";
+
+export interface PlatformConnection {
+  userId: string;
+  platform: SocialPlatform;
+  /** Encrypted / raw access token — handle with care, never log */
+  accessToken: string | null;
+  /** Encrypted / raw refresh token */
+  refreshToken: string | null;
+  /** Display handle or channel name returned by the provider */
+  username: string | null;
+  connectedAt: string; // ISO-8601
+}
+
+/**
+ * Keyed by `${userId}::${platform}` so look-ups and upserts are O(1).
+ */
+const store = new Map<string, PlatformConnection>();
+
+function key(userId: string, platform: SocialPlatform) {
+  return `${userId}::${platform}`;
+}
+
+/** Upsert a connection. Creates a new record or replaces the existing one. */
+export function upsertConnection(conn: PlatformConnection): void {
+  store.set(key(conn.userId, conn.platform), { ...conn });
+}
+
+/** Return all connections for a given user (ordered by connectedAt desc). */
+export function getConnections(userId: string): PlatformConnection[] {
+  const result: PlatformConnection[] = [];
+  for (const conn of store.values()) {
+    if (conn.userId === userId) result.push(conn);
+  }
+  return result.sort(
+    (a, b) => new Date(b.connectedAt).getTime() - new Date(a.connectedAt).getTime()
+  );
+}
+
+/** Remove a specific platform connection. Returns true if a record was deleted. */
+export function deleteConnection(userId: string, platform: SocialPlatform): boolean {
+  return store.delete(key(userId, platform));
+}
+
+/** Check whether a user has a specific platform connected. */
+export function hasConnection(userId: string, platform: SocialPlatform): boolean {
+  return store.has(key(userId, platform));
+}

--- a/clips-frontend/app/lib/transformQuota.ts
+++ b/clips-frontend/app/lib/transformQuota.ts
@@ -1,0 +1,133 @@
+/**
+ * In-memory transform quota store.
+ *
+ * Follows the same no-database pattern used by platformConnections.ts and
+ * the job store in app/api/jobs/[id]/route.ts.
+ *
+ * Plan limits (transforms per calendar month, UTC):
+ *   free       →  3
+ *   pro        → 50
+ *   enterprise → Infinity (unlimited)
+ *
+ * Quotas reset on the 1st of each month at 00:00 UTC.
+ */
+
+export type Plan = "free" | "pro" | "enterprise";
+
+/** Monthly limit per plan. */
+export const PLAN_LIMITS: Record<Plan, number> = {
+  free: 3,
+  pro: 50,
+  enterprise: Infinity,
+};
+
+interface QuotaRecord {
+  userId: string;
+  plan: Plan;
+  /** Number of transforms consumed in the current billing period. */
+  used: number;
+  /**
+   * ISO-8601 timestamp of the next reset (1st of the following month, 00:00 UTC).
+   * Stored so we can return it to callers without recomputing every request.
+   */
+  resetAt: string;
+}
+
+/** Keyed by userId for O(1) look-up. */
+const store = new Map<string, QuotaRecord>();
+
+/* ─── Helpers ────────────────────────────────────────────────────────────────── */
+
+/** Returns an ISO-8601 string for 00:00 UTC on the 1st of next month. */
+export function nextResetDate(from: Date = new Date()): string {
+  const d = new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth() + 1, 1, 0, 0, 0, 0)
+  );
+  return d.toISOString();
+}
+
+/**
+ * Returns true when the stored resetAt timestamp has passed, meaning the
+ * current billing period has expired and the quota should be cleared.
+ */
+function isExpired(record: QuotaRecord): boolean {
+  return Date.now() >= new Date(record.resetAt).getTime();
+}
+
+/* ─── Public API ─────────────────────────────────────────────────────────────── */
+
+/**
+ * Fetch (or lazily create) the quota record for a user.
+ * Automatically resets `used` to 0 when the billing period has rolled over.
+ */
+export function getQuota(userId: string, plan: Plan): QuotaRecord {
+  let record = store.get(userId);
+
+  if (!record) {
+    record = {
+      userId,
+      plan,
+      used: 0,
+      resetAt: nextResetDate(),
+    };
+    store.set(userId, record);
+    return record;
+  }
+
+  // Always keep the plan in sync (user may have upgraded/downgraded).
+  record.plan = plan;
+
+  // Roll over if the billing period has expired.
+  if (isExpired(record)) {
+    record.used = 0;
+    record.resetAt = nextResetDate();
+  }
+
+  return record;
+}
+
+/**
+ * Returns the number of transforms remaining for this billing period.
+ * `Infinity` for enterprise users.
+ */
+export function getRemainingQuota(userId: string, plan: Plan): number {
+  const record = getQuota(userId, plan);
+  const limit = PLAN_LIMITS[plan];
+  if (limit === Infinity) return Infinity;
+  return Math.max(0, limit - record.used);
+}
+
+/**
+ * Attempts to consume one transform credit.
+ *
+ * @returns `{ allowed: true, remaining: number }` when quota is available.
+ * @returns `{ allowed: false, remaining: 0, resetAt: string }` when exhausted.
+ */
+export function consumeQuota(
+  userId: string,
+  plan: Plan
+): { allowed: true; remaining: number } | { allowed: false; remaining: 0; resetAt: string } {
+  const record = getQuota(userId, plan);
+  const limit = PLAN_LIMITS[plan];
+
+  // Enterprise = unlimited.
+  if (limit === Infinity) {
+    return { allowed: true, remaining: Infinity };
+  }
+
+  if (record.used >= limit) {
+    return { allowed: false, remaining: 0, resetAt: record.resetAt };
+  }
+
+  record.used += 1;
+  return { allowed: true, remaining: limit - record.used };
+}
+
+/**
+ * Forcibly set the used count for a user — useful for seeding test data
+ * or admin overrides.
+ */
+export function setUsed(userId: string, plan: Plan, used: number): void {
+  const record = getQuota(userId, plan);
+  record.used = Math.max(0, used);
+}

--- a/clips-frontend/app/lib/types/clip.ts
+++ b/clips-frontend/app/lib/types/clip.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared Clip type used across API routes, the vault, and the clips grid.
+ * Transformations are stored as a sub-array so a single clip can have
+ * multiple AI-style variants without replacing the original.
+ */
+
+export interface ClipTransformation {
+  /** The style ID from /api/transform/styles (e.g. "anime", "neon-noir") */
+  style: string;
+  /** Human-readable style label (e.g. "Neon Noir") */
+  styleLabel: string;
+  /** Publicly accessible URL of the transformed clip (MP4) */
+  resultUrl: string;
+  /** Background processing job ID (used for polling status) */
+  jobId: string;
+  /** ISO-8601 timestamp */
+  createdAt: string;
+}
+
+export type ClipRarity = "common" | "uncommon" | "rare" | "epic" | "legendary";
+export type ClipStatus = "ready_to_mint" | "queue" | "minted";
+
+export interface Clip {
+  id: string;
+  title: string;
+  /** URL of the cover thumbnail */
+  thumbnail: string;
+  /** URL of the original source video (MP4) */
+  videoUrl?: string;
+  /** Formatted duration string, e.g. "1:23" */
+  duration?: string;
+  /** AI quality score 0-100 */
+  aiScore?: number;
+  floorPrice?: number;
+  currentValue?: number;
+  status: ClipStatus;
+  rarity?: ClipRarity;
+  mintedDate?: string;
+  listedDate?: string;
+  queuePosition?: number;
+  /** All AI transformations applied to this clip. Empty array = original only. */
+  transformations: ClipTransformation[];
+}

--- a/clips-frontend/app/platforms/page.tsx
+++ b/clips-frontend/app/platforms/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useCallback } from "react";
 import Link from "next/link";
 import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
 import SectionHeader from "@/components/platforms/SectionHeader";
@@ -13,12 +13,11 @@ import {
   Share2,
   Wallet,
   Menu,
-  AlertCircle,
-  X,
 } from "lucide-react";
 import { useAuth } from "@/components/AuthProvider";
 import { useWallet, truncateAddress } from "@/components/WalletProvider";
 import Skeleton from "@/components/ui/Skeleton";
+import { signIn, signOut } from "next-auth/react";
 
 /* ================= TYPES ================= */
 
@@ -34,6 +33,14 @@ type PlatformItem = {
   isLoading?: boolean;
   isComingSoon?: boolean;
 };
+
+/** Shape returned by GET /api/platforms/connections */
+interface StoredConnection {
+  userId: string;
+  platform: string;
+  username: string | null;
+  connectedAt: string;
+}
 
 /* ================= ICONS ================= */
 
@@ -81,6 +88,12 @@ export default function PlatformsPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [search, setSearch] = useState("");
 
+  // ── Platform connections from /api/platforms/connections ──────────────────
+  const [connections, setConnections] = useState<StoredConnection[]>([]);
+  const [connectionsLoading, setConnectionsLoading] = useState(true);
+  const [connectingId, setConnectingId] = useState<string | null>(null);
+  const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
+
   const {
     isConnected: walletConnected,
     isConnecting: walletConnecting,
@@ -93,40 +106,112 @@ export default function PlatformsPage() {
     isRestoringSession,
   } = useWallet();
 
-  const pageLoading = authLoading || isRestoringSession;
+  const pageLoading = authLoading || isRestoringSession || connectionsLoading;
+
+  // ── Fetch persisted connections ────────────────────────────────────────────
+  const fetchConnections = useCallback(async () => {
+    try {
+      const res = await fetch("/api/platforms/connections");
+      if (res.ok) {
+        const data = await res.json();
+        setConnections(data.connections ?? []);
+      }
+    } catch {
+      // Non-fatal — falls back to "NOT LINKED" for all social platforms
+    } finally {
+      setConnectionsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConnections();
+  }, [fetchConnections]);
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  function getConnection(platform: string): StoredConnection | undefined {
+    return connections.find((c) => c.platform === platform);
+  }
+
+  function isConnected(providerId: string): boolean {
+    return !!getConnection(providerId);
+  }
+
+  function getUsername(providerId: string): string | undefined {
+    return getConnection(providerId)?.username ?? undefined;
+  }
+
+  async function handleConnect(platformId: string) {
+    setConnectingId(platformId);
+    try {
+      await signIn(platformId, { callbackUrl: "/platforms" });
+      await fetchConnections();
+    } catch (error) {
+      console.error(`Failed to connect to ${platformId}:`, error);
+    } finally {
+      setConnectingId(null);
+    }
+  }
+
+  async function handleDisconnect(platformId: string) {
+    setDisconnectingId(platformId);
+    try {
+      await fetch(`/api/platforms/connections?platform=${platformId}`, {
+        method: "DELETE",
+      });
+      setConnections((prev) => prev.filter((c) => c.platform !== platformId));
+    } catch (error) {
+      console.error(`Failed to disconnect from ${platformId}:`, error);
+    } finally {
+      setDisconnectingId(null);
+    }
+  }
 
   /* ================= DATA ================= */
 
   const socialPlatforms: PlatformItem[] = [
     {
       name: "TikTok",
-      username: "@clip_creator_pro",
+      username: getUsername("tiktok"),
       description: "Manage your main TikTok video feed",
       icon: TikTokIcon,
-      status: "ACTIVE",
-      ctaText: "Manage",
+      status: isConnected("tiktok") ? "ACTIVE" : "NOT LINKED",
+      ctaText: connectingId === "tiktok" ? "Connecting..." : isConnected("tiktok") ? "Manage" : "Connect Account",
+      onConnect: () => handleConnect("tiktok"),
+      onDisconnect: () => handleDisconnect("tiktok"),
+      isLoading: connectingId === "tiktok" || disconnectingId === "tiktok",
     },
     {
       name: "Instagram",
+      username: getUsername("instagram"),
       description: "Connect to sync Reels",
       icon: InstagramIcon,
-      status: "NOT LINKED",
-      ctaText: "Connect Account",
+      status: isConnected("instagram") ? "ACTIVE" : "NOT LINKED",
+      ctaText: connectingId === "instagram" ? "Connecting..." : isConnected("instagram") ? "Manage" : "Connect Account",
+      onConnect: () => handleConnect("instagram"),
+      onDisconnect: () => handleDisconnect("instagram"),
+      isLoading: connectingId === "instagram" || disconnectingId === "instagram",
     },
     {
       name: "YouTube",
-      username: "StudioX Channel",
+      username: getUsername("google"),
       description: "Import and sync your YouTube content",
       icon: YoutubeIcon,
-      status: "ACTIVE",
-      ctaText: "Manage",
+      status: isConnected("google") ? "ACTIVE" : "NOT LINKED",
+      ctaText: connectingId === "google" ? "Connecting..." : isConnected("google") ? "Manage" : "Connect Account",
+      onConnect: () => handleConnect("google"),
+      onDisconnect: () => handleDisconnect("google"),
+      isLoading: connectingId === "google" || disconnectingId === "google",
     },
     {
       name: "X / Twitter",
+      username: getUsername("twitter"),
       description: "Auto-post clips to X",
       icon: TwitterIcon,
-      status: "NOT LINKED",
-      ctaText: "Connect Account",
+      status: isConnected("twitter") ? "ACTIVE" : "NOT LINKED",
+      ctaText: connectingId === "twitter" ? "Connecting..." : isConnected("twitter") ? "Manage" : "Connect Account",
+      onConnect: () => handleConnect("twitter"),
+      onDisconnect: () => handleDisconnect("twitter"),
+      isLoading: connectingId === "twitter" || disconnectingId === "twitter",
     },
   ];
 
@@ -164,13 +249,15 @@ export default function PlatformsPage() {
     return socialPlatforms.filter((p) =>
       p.name.toLowerCase().includes(search.toLowerCase())
     );
-  }, [search]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, connections, connectingId, disconnectingId]);
 
   const filteredWallets = useMemo(() => {
     return walletPlatforms.filter((p) =>
       p.name.toLowerCase().includes(search.toLowerCase())
     );
-  }, [search]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, walletConnected, walletConnecting, walletAddress]);
 
   const noResults =
     filteredSocial.length === 0 && filteredWallets.length === 0;

--- a/clips-frontend/app/store/api.ts
+++ b/clips-frontend/app/store/api.ts
@@ -1,4 +1,5 @@
 import type { DashboardStats, RevenuePoint, Project, UserProfile, EarningsBreakdownItem } from "./types";
+import { getRemainingQuota, nextResetDate } from "@/app/lib/transformQuota";
 
 const MOCK_STATS: DashboardStats = {
   earnings: { total: "$12,450.80", trend: 12.5, trendLabel: "+12.5% from last month" },
@@ -29,18 +30,23 @@ export async function fetchDashboardFromAPI(): Promise<{
   };
 }
 
-const MOCK_PROFILE: UserProfile = {
+const MOCK_PROFILE_BASE = {
   id: "usr_001",
   name: "Alex Rivera",
   email: "alex@clipcash.ai",
   avatarUrl: "/avatar.png",
-  plan: "pro",
+  plan: "pro" as const,
   planUsagePercent: 80,
 };
 
 export async function fetchUserFromAPI(): Promise<UserProfile> {
   await new Promise((resolve) => setTimeout(resolve, 500));
-  return MOCK_PROFILE;
+  // Refresh quota fields on every fetch so they stay in sync with the server store.
+  return {
+    ...MOCK_PROFILE_BASE,
+    transformQuotaRemaining: getRemainingQuota(MOCK_PROFILE_BASE.id, MOCK_PROFILE_BASE.plan),
+    transformQuotaResetAt: nextResetDate(),
+  };
 }
 
 const MOCK_BREAKDOWN: EarningsBreakdownItem[] = [

--- a/clips-frontend/app/store/types.ts
+++ b/clips-frontend/app/store/types.ts
@@ -129,6 +129,16 @@ export interface UserProfile {
   avatarUrl: string | null;
   plan: "free" | "pro" | "enterprise";
   planUsagePercent: number;
+  /**
+   * How many AI transforms remain in the current billing period.
+   * `null` means unlimited (enterprise plan).
+   */
+  transformQuotaRemaining: number | null;
+  /**
+   * ISO-8601 date when the quota resets (1st of next month, 00:00 UTC).
+   * `null` for enterprise (no reset needed).
+   */
+  transformQuotaResetAt: string | null;
 }
 
 export interface UserState {

--- a/clips-frontend/app/vault/page.tsx
+++ b/clips-frontend/app/vault/page.tsx
@@ -5,9 +5,16 @@ import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
 import DashboardHeader from "@/components/dashboard/DashboardHeader";
 import VaultSidebar from "@/components/vault/VaultSidebar";
 import NFTGrid from "@/components/vault/NFTGrid";
-import MintConfigForm from "@/components/projects/MintConfigForm";
+import MintConfigForm, {
+  type SelectedClipVersion,
+} from "@/components/projects/MintConfigForm";
 import { MockApi } from "@/app/lib/mockApi";
 import { ChevronRight } from "lucide-react";
+import type { Clip } from "@/app/lib/types/clip";
+
+type SelectedClipWithTransforms = SelectedClipVersion & {
+  transformations?: Clip["transformations"];
+};
 
 export default function VaultPage() {
   const [loading, setLoading] = useState(true);
@@ -15,11 +22,40 @@ export default function VaultPage() {
   const [activeFilter, setActiveFilter] = useState<"pending" | "listed" | "history">("pending");
   const [showMintPanel, setShowMintPanel] = useState(false);
 
+  /**
+   * Tracks which clip (and which version) is queued for minting.
+   * Set when the user clicks "Mint Now" on an NFTCard or picks a version
+   * in the VersionPicker inside MintConfigForm.
+   */
+  const [pendingMint, setPendingMint] =
+    useState<SelectedClipWithTransforms | null>(null);
+
   // Simulate loading delay
   useEffect(() => {
     const timer = setTimeout(() => setLoading(false), 1500);
     return () => clearTimeout(timer);
   }, []);
+
+  const handleMintSelect = (clip: {
+    id: string;
+    title: string;
+    versionUrl: string;
+    isTransformed: boolean;
+    style?: string;
+    styleLabel?: string;
+    transformations?: Clip["transformations"];
+  }) => {
+    setPendingMint({
+      clipId: clip.id,
+      title: clip.title,
+      versionUrl: clip.versionUrl,
+      isTransformed: clip.isTransformed,
+      style: clip.style,
+      styleLabel: clip.styleLabel,
+      transformations: clip.transformations,
+    });
+    setShowMintPanel(true);
+  };
 
   const handleMintSubmit = async (data: {
     collectionName: string;
@@ -30,8 +66,6 @@ export default function VaultPage() {
     // Call the actual minting API
     const result = await MockApi.mintCollection(data);
     console.log("Minting successful:", result);
-    // You could add additional logic here like showing a toast notification
-    // or updating the NFT grid with the new collection
     return result;
   };
 
@@ -87,9 +121,13 @@ export default function VaultPage() {
 
             {/* Grid + Right Panel */}
             <div className="flex-1 min-w-0 flex flex-col lg:flex-row gap-6">
-              {/* NFT Grid */}
+              {/* NFT Grid — fetches from /api/clips and passes transformations */}
               <div className="flex-1 min-w-0">
-                <NFTGrid filter={activeFilter} loading={loading} />
+                <NFTGrid
+                  filter={activeFilter}
+                  loading={loading}
+                  onMintSelect={handleMintSelect}
+                />
               </div>
 
               {/* Mint Configuration Panel (Desktop) */}
@@ -107,7 +145,15 @@ export default function VaultPage() {
 
                   {showMintPanel && (
                     <div className="animate-in fade-in slide-in-from-top-2 duration-300">
-                      <MintConfigForm onSubmit={handleMintSubmit} />
+                      <MintConfigForm
+                        onSubmit={handleMintSubmit}
+                        selectedClip={pendingMint ?? undefined}
+                        onVersionChange={(v) =>
+                          setPendingMint((prev) =>
+                            prev ? { ...prev, ...v } : null
+                          )
+                        }
+                      />
                     </div>
                   )}
                 </div>
@@ -125,7 +171,15 @@ export default function VaultPage() {
                 {showMintPanel && (
                   <div className="mt-6 bg-input border border-white/10 rounded-[20px] p-6 animate-in fade-in slide-in-from-top-2 duration-300">
                     <h3 className="text-[18px] font-extrabold text-white mb-6">Mint Configuration</h3>
-                    <MintConfigForm onSubmit={handleMintSubmit} />
+                    <MintConfigForm
+                      onSubmit={handleMintSubmit}
+                      selectedClip={pendingMint ?? undefined}
+                      onVersionChange={(v) =>
+                        setPendingMint((prev) =>
+                          prev ? { ...prev, ...v } : null
+                        )
+                      }
+                    />
                   </div>
                 )}
               </div>

--- a/clips-frontend/components/transform/StylePicker.stories.tsx
+++ b/clips-frontend/components/transform/StylePicker.stories.tsx
@@ -1,0 +1,355 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import StylePicker from "./StylePicker";
+import type { TransformStyle, QuotaInfo } from "./StylePicker";
+
+/* ─── Fixture: styles ─────────────────────────────────────────────────────────── */
+
+const ALL_STYLES: TransformStyle[] = [
+  {
+    id: "anime",
+    name: "Anime",
+    thumbnailBefore: "https://placehold.co/200x88/101614/5A6F65?text=Before",
+    thumbnailAfter: "https://placehold.co/200x88/FF6B9D/101614?text=Anime",
+    avgDurationSeconds: 45,
+    description: "Vivid cel-shading and bold outlines",
+    accentColor: "#FF6B9D",
+  },
+  {
+    id: "cinematic",
+    name: "Cinematic",
+    thumbnailBefore: "https://placehold.co/200x88/101614/5A6F65?text=Before",
+    thumbnailAfter: "https://placehold.co/200x88/E2B04A/101614?text=Cinematic",
+    avgDurationSeconds: 30,
+    description: "Film-grade colour grading & letterbox",
+    accentColor: "#E2B04A",
+  },
+  {
+    id: "sketch",
+    name: "Sketch",
+    thumbnailBefore: "https://placehold.co/200x88/101614/5A6F65?text=Before",
+    thumbnailAfter: "https://placehold.co/200x88/A0AEC0/101614?text=Sketch",
+    avgDurationSeconds: 25,
+    description: "Hand-drawn pencil & charcoal look",
+    accentColor: "#A0AEC0",
+  },
+  {
+    id: "watercolor",
+    name: "Watercolor",
+    thumbnailBefore: "https://placehold.co/200x88/101614/5A6F65?text=Before",
+    thumbnailAfter: "https://placehold.co/200x88/76C7F0/101614?text=Watercolor",
+    avgDurationSeconds: 50,
+    description: "Soft pigment bleeds on textured paper",
+    accentColor: "#76C7F0",
+  },
+  {
+    id: "retro-vhs",
+    name: "Retro VHS",
+    thumbnailBefore: "https://placehold.co/200x88/101614/5A6F65?text=Before",
+    thumbnailAfter: "https://placehold.co/200x88/00E58F/101614?text=VHS",
+    avgDurationSeconds: 20,
+    description: "80s scan lines, glitch & chromatic aberration",
+    accentColor: "#00E58F",
+  },
+  {
+    id: "neon-noir",
+    name: "Neon Noir",
+    thumbnailBefore: "https://placehold.co/200x88/101614/5A6F65?text=Before",
+    thumbnailAfter: "https://placehold.co/200x88/9D4EDD/101614?text=Neon+Noir",
+    avgDurationSeconds: 40,
+    description: "Rain-soaked streets with cyberpunk glow",
+    accentColor: "#9D4EDD",
+  },
+];
+
+/* ─── Fixture: quota states ───────────────────────────────────────────────────── */
+
+const QUOTA_FREE_FULL: QuotaInfo = {
+  remaining: 3,
+  limit: 3,
+  resetAt: "2025-08-01T00:00:00.000Z",
+  unlimited: false,
+};
+
+const QUOTA_PRO_PARTIAL: QuotaInfo = {
+  remaining: 27,
+  limit: 50,
+  resetAt: "2025-08-01T00:00:00.000Z",
+  unlimited: false,
+};
+
+const QUOTA_PRO_LOW: QuotaInfo = {
+  remaining: 2,
+  limit: 50,
+  resetAt: "2025-08-01T00:00:00.000Z",
+  unlimited: false,
+};
+
+const QUOTA_EXHAUSTED: QuotaInfo = {
+  remaining: 0,
+  limit: 3,
+  resetAt: "2025-08-01T00:00:00.000Z",
+  unlimited: false,
+};
+
+const QUOTA_UNLIMITED: QuotaInfo = {
+  remaining: null,
+  limit: null,
+  resetAt: null,
+  unlimited: true,
+};
+
+/* ─── Meta ───────────────────────────────────────────────────────────────────── */
+
+const meta = {
+  title: "Transform/StylePicker",
+  component: StylePicker,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: [
+          "Grid of AI transformation style preset cards.",
+          "Selecting a card triggers a low-res preview before full processing.",
+          "",
+          "**Quota system:** A `QuotaBar` is displayed above the grid showing",
+          "transforms remaining this month. When quota reaches 0 all unselected",
+          "cards are disabled and an Upgrade Plan CTA appears.",
+          "",
+          "Styles are fetched from `GET /api/transform/styles`.",
+          "Quota is fetched from `GET /api/transform`.",
+        ].join("\n"),
+      },
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    onSelect: fn(),
+    styles: ALL_STYLES,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+  argTypes: {
+    selectedStyleId: {
+      control: "select",
+      options: [
+        null,
+        "anime",
+        "cinematic",
+        "sketch",
+        "watercolor",
+        "retro-vhs",
+        "neon-noir",
+      ],
+      description: "Currently selected style ID (controlled)",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disable all cards (e.g. full processing is running)",
+    },
+  },
+} satisfies Meta<typeof StylePicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ─── Core interaction stories ───────────────────────────────────────────────── */
+
+/** Default idle state — no style selected, pro quota with headroom. */
+export const Default: Story = {
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+};
+
+/** One card in the selected (post-preview) state. */
+export const WithSelection: Story = {
+  args: {
+    selectedStyleId: "cinematic",
+    disabled: false,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+};
+
+/** All cards disabled — simulates full-processing in progress. */
+export const Disabled: Story = {
+  args: {
+    selectedStyleId: null,
+    disabled: true,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+};
+
+/** Selected + disabled — style chosen, processing has started. */
+export const SelectedAndDisabled: Story = {
+  args: {
+    selectedStyleId: "neon-noir",
+    disabled: true,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+};
+
+/* ─── Quota stories ──────────────────────────────────────────────────────────── */
+
+/**
+ * Free plan, full quota (3/3 remaining).
+ * Bar is green, no CTA shown.
+ */
+export const QuotaFreePlanFull: Story = {
+  name: "Quota — Free plan (3 / 3 remaining)",
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_FREE_FULL,
+  },
+};
+
+/**
+ * Pro plan, partially consumed (27/50 remaining).
+ * Bar is green with moderate fill.
+ */
+export const QuotaProPartial: Story = {
+  name: "Quota — Pro plan (27 / 50 remaining)",
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+};
+
+/**
+ * Pro plan, critically low (2/50 remaining).
+ * Bar turns red as a warning.
+ */
+export const QuotaProLow: Story = {
+  name: "Quota — Pro plan (2 / 50 remaining, critical)",
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_PRO_LOW,
+  },
+};
+
+/**
+ * Quota fully exhausted (0/3 on free plan).
+ * All unselected cards are disabled, upgrade CTA banner appears above the grid,
+ * and quota bar shows "Quota exhausted" in red.
+ */
+export const QuotaExhausted: Story = {
+  name: "Quota — Exhausted (0 / 3, upgrade CTA shown)",
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_EXHAUSTED,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When all transforms are consumed the cards are blocked and a prominent "Upgrade Plan" CTA is shown.",
+      },
+    },
+  },
+};
+
+/**
+ * Quota exhausted but a style is already selected.
+ * The selected card stays interactive (Apply style); all others remain disabled.
+ */
+export const QuotaExhaustedWithSelection: Story = {
+  name: "Quota — Exhausted with existing selection",
+  args: {
+    selectedStyleId: "anime",
+    disabled: false,
+    quota: QUOTA_EXHAUSTED,
+  },
+};
+
+/**
+ * Enterprise plan — unlimited transforms.
+ * Bar shows the infinity icon and "Unlimited transforms" label.
+ */
+export const QuotaUnlimited: Story = {
+  name: "Quota — Enterprise (unlimited)",
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_UNLIMITED,
+  },
+};
+
+/* ─── Loading story ───────────────────────────────────────────────────────────── */
+
+/**
+ * Loading skeleton — no styles or quota prop, so both fetches are in-flight.
+ * The quota bar skeleton and style card skeletons are shown.
+ */
+export const Loading: Story = {
+  args: {
+    styles: undefined,
+    quota: undefined,
+    selectedStyleId: null,
+    disabled: false,
+  },
+  parameters: {
+    fetchMock: {
+      mocks: [
+        {
+          matcher: { url: "/api/transform/styles" },
+          response: new Promise(() => {}),
+        },
+        {
+          matcher: { url: "/api/transform" },
+          response: new Promise(() => {}),
+        },
+      ],
+    },
+    docs: {
+      description: {
+        story:
+          "Both the quota bar and card grid show skeleton placeholders while data is in-flight.",
+      },
+    },
+  },
+};
+
+/* ─── Full-grid comparison ────────────────────────────────────────────────────── */
+
+/** All 6 styles, interactive, with a healthy pro quota. */
+export const AllStyles: Story = {
+  args: {
+    selectedStyleId: null,
+    disabled: false,
+    quota: QUOTA_PRO_PARTIAL,
+  },
+  render: (args) => (
+    <div className="space-y-6">
+      <p className="text-[13px] text-muted-foreground">
+        All 6 V1 styles — click any card to see the preview flow.
+      </p>
+      <StylePicker {...args} />
+    </div>
+  ),
+};
+
+/* ─── Per-style isolation stories ────────────────────────────────────────────── */
+
+export const AnimeStyle: Story = {
+  args: { selectedStyleId: "anime", quota: QUOTA_PRO_PARTIAL },
+};
+export const CinematicStyle: Story = {
+  args: { selectedStyleId: "cinematic", quota: QUOTA_PRO_PARTIAL },
+};
+export const SketchStyle: Story = {
+  args: { selectedStyleId: "sketch", quota: QUOTA_PRO_PARTIAL },
+};
+export const WatercolorStyle: Story = {
+  args: { selectedStyleId: "watercolor", quota: QUOTA_PRO_PARTIAL },
+};
+export const RetroVhsStyle: Story = {
+  args: { selectedStyleId: "retro-vhs", quota: QUOTA_PRO_PARTIAL },
+};
+export const NeonNoirStyle: Story = {
+  args: { selectedStyleId: "neon-noir", quota: QUOTA_PRO_PARTIAL },
+};

--- a/clips-frontend/components/transform/StylePicker.tsx
+++ b/clips-frontend/components/transform/StylePicker.tsx
@@ -1,0 +1,642 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, useId } from "react";
+import Link from "next/link";
+import {
+  Clock,
+  Zap,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+  ArrowUpRight,
+  Infinity as InfinityIcon,
+} from "lucide-react";
+import Skeleton from "@/components/ui/Skeleton";
+import type { TransformStyle } from "@/app/api/transform/styles/route";
+
+/* ─── Re-export so consumers can import from this module ────────────────────── */
+export type { TransformStyle };
+
+/* ─── Types ──────────────────────────────────────────────────────────────────── */
+
+export interface QuotaInfo {
+  /**
+   * Transforms remaining this month.
+   * `null` means unlimited (enterprise).
+   */
+  remaining: number | null;
+  /** Total monthly allowance. `null` means unlimited. */
+  limit: number | null;
+  /** ISO-8601 date of the next quota reset. `null` for unlimited plans. */
+  resetAt: string | null;
+  /** true when the plan has no cap at all */
+  unlimited: boolean;
+}
+
+export interface StylePickerProps {
+  /** Currently selected style ID (controlled). */
+  selectedStyleId?: string | null;
+  /**
+   * Called when the user picks a style.
+   * `isPreview` is true while the low-res preview is generating,
+   * false once it resolves and the selection is confirmed.
+   */
+  onSelect?: (style: TransformStyle, isPreview: boolean) => void;
+  /** Disable all cards (e.g. full processing is already running). */
+  disabled?: boolean;
+  /**
+   * Provide the style list directly — skips the internal fetch.
+   * Useful for Storybook and unit tests.
+   */
+  styles?: TransformStyle[];
+  /**
+   * Provide quota data directly — skips the internal fetch.
+   * When omitted the component fetches GET /api/transform.
+   */
+  quota?: QuotaInfo;
+}
+
+/* ─── Helpers ────────────────────────────────────────────────────────────────── */
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `~${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s === 0 ? `~${m}m` : `~${m}m ${s}s`;
+}
+
+function formatResetDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/* ─── Quota bar ──────────────────────────────────────────────────────────────── */
+
+interface QuotaBarProps {
+  quota: QuotaInfo;
+}
+
+function QuotaBar({ quota }: QuotaBarProps) {
+  if (quota.unlimited) {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-brand/10 border border-brand/20">
+        <InfinityIcon className="w-4 h-4 text-brand shrink-0" />
+        <span className="text-[13px] font-bold text-brand">
+          Unlimited transforms
+        </span>
+        <span className="text-[12px] text-muted-foreground ml-auto">
+          Enterprise plan
+        </span>
+      </div>
+    );
+  }
+
+  const { remaining, limit, resetAt } = quota;
+  const isExhausted = remaining !== null && remaining <= 0;
+  const pct =
+    remaining !== null && limit !== null && limit > 0
+      ? Math.round(((limit - remaining) / limit) * 100)
+      : 0;
+
+  // Colour the bar: green → yellow at 60% used → red at 90% used
+  const barColor =
+    pct >= 90
+      ? "#EF4444"
+      : pct >= 60
+      ? "#FACC15"
+      : "#00E58F";
+
+  return (
+    <div
+      className={[
+        "rounded-xl border px-4 py-3 space-y-2",
+        isExhausted
+          ? "bg-red-500/10 border-red-500/20"
+          : "bg-surface/60 border-white/[0.06]",
+      ].join(" ")}
+      role="status"
+      aria-label={`Transform quota: ${remaining ?? 0} of ${limit} remaining`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Sparkles
+            className="w-3.5 h-3.5 shrink-0"
+            style={{ color: isExhausted ? "#EF4444" : "#00E58F" }}
+          />
+          <span
+            className={[
+              "text-[13px] font-bold",
+              isExhausted ? "text-red-400" : "text-white",
+            ].join(" ")}
+          >
+            {isExhausted
+              ? "Quota exhausted"
+              : `${remaining} transform${remaining === 1 ? "" : "s"} remaining`}
+          </span>
+        </div>
+
+        {resetAt && (
+          <span className="text-[11px] text-muted-foreground shrink-0">
+            Resets {formatResetDate(resetAt)}
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      {limit !== null && (
+        <div
+          className="w-full h-1.5 rounded-full overflow-hidden bg-white/[0.06]"
+          aria-hidden="true"
+        >
+          <div
+            className="h-full rounded-full transition-all duration-700 ease-out"
+            style={{
+              width: `${pct}%`,
+              backgroundColor: barColor,
+              boxShadow: `0 0 8px ${barColor}66`,
+            }}
+          />
+        </div>
+      )}
+
+      {/* Upgrade CTA when exhausted */}
+      {isExhausted && (
+        <Link
+          href="/settings?tab=billing"
+          className="mt-1 flex items-center gap-1.5 w-fit text-[12px] font-bold text-brand hover:text-brand-hover transition-colors"
+        >
+          <ArrowUpRight className="w-3.5 h-3.5" />
+          Upgrade plan to continue
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/* ─── Quota skeleton ─────────────────────────────────────────────────────────── */
+
+function QuotaBarSkeleton() {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-surface/60 px-4 py-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3 w-20" />
+      </div>
+      <Skeleton className="h-1.5 w-full rounded-full" />
+    </div>
+  );
+}
+
+/* ─── Placeholder thumbnail ──────────────────────────────────────────────────── */
+
+function ThumbnailPlaceholder({
+  accentColor,
+  label,
+}: {
+  accentColor: string;
+  label: string;
+}) {
+  return (
+    <div
+      className="w-full h-full flex items-center justify-center rounded-[10px]"
+      style={{ background: `${accentColor}18` }}
+      aria-label={label}
+    >
+      <span
+        className="text-[10px] font-bold uppercase tracking-widest opacity-40"
+        style={{ color: accentColor }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/* ─── Before / After thumbnail strip ────────────────────────────────────────── */
+
+interface ThumbnailStripProps {
+  style: TransformStyle;
+  revealAfter: boolean;
+}
+
+function ThumbnailStrip({ style, revealAfter }: ThumbnailStripProps) {
+  const [beforeLoaded, setBeforeLoaded] = useState(false);
+  const [afterLoaded, setAfterLoaded] = useState(false);
+
+  return (
+    <div className="relative w-full h-[88px] rounded-[10px] overflow-hidden bg-surface-hover flex">
+      {/* Before */}
+      <div className="relative flex-1 overflow-hidden">
+        {!beforeLoaded && (
+          <ThumbnailPlaceholder accentColor={style.accentColor} label="before" />
+        )}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={style.thumbnailBefore}
+          alt={`${style.name} before`}
+          onLoad={() => setBeforeLoaded(true)}
+          onError={() => setBeforeLoaded(false)}
+          className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-300 ${
+            beforeLoaded ? "opacity-100" : "opacity-0"
+          }`}
+        />
+        <span className="absolute bottom-1 left-1.5 text-[9px] font-black uppercase tracking-wider text-white/50 bg-black/40 px-1.5 py-0.5 rounded-md">
+          Before
+        </span>
+      </div>
+
+      {/* Divider */}
+      <div className="w-px bg-white/10 shrink-0" />
+
+      {/* After */}
+      <div className="relative flex-1 overflow-hidden">
+        {!afterLoaded && (
+          <ThumbnailPlaceholder accentColor={style.accentColor} label="after" />
+        )}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={style.thumbnailAfter}
+          alt={`${style.name} after`}
+          onLoad={() => setAfterLoaded(true)}
+          onError={() => setAfterLoaded(false)}
+          className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-500 ${
+            afterLoaded && revealAfter ? "opacity-100" : "opacity-0"
+          }`}
+        />
+        {revealAfter && (
+          <div
+            className="absolute inset-0 transition-opacity duration-500"
+            style={{
+              background: `radial-gradient(circle at 50% 50%, ${style.accentColor}22, transparent 70%)`,
+            }}
+          />
+        )}
+        <span className="absolute bottom-1 right-1.5 text-[9px] font-black uppercase tracking-wider text-white/50 bg-black/40 px-1.5 py-0.5 rounded-md">
+          After
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Single style card ──────────────────────────────────────────────────────── */
+
+interface StyleCardProps {
+  style: TransformStyle;
+  isSelected: boolean;
+  isPreviewing: boolean;
+  /** Card-level disabled: either global disabled prop or quota exhausted */
+  disabled: boolean;
+  quotaExhausted: boolean;
+  onSelect: (style: TransformStyle) => void;
+  headingId: string;
+}
+
+function StyleCard({
+  style,
+  isSelected,
+  isPreviewing,
+  disabled,
+  quotaExhausted,
+  onSelect,
+  headingId,
+}: StyleCardProps) {
+  const isThisPreviewing = isPreviewing && isSelected;
+  const showAfter = isSelected && !isThisPreviewing;
+
+  return (
+    <article
+      aria-labelledby={headingId}
+      aria-selected={isSelected}
+      className={[
+        "relative flex flex-col gap-4 rounded-[20px] p-5 border transition-all duration-300",
+        "bg-surface/40 backdrop-blur-md",
+        isSelected
+          ? "border-[2px]"
+          : "border border-white/[0.05] hover:border-white/10",
+        disabled && !isSelected ? "opacity-50" : "",
+      ].join(" ")}
+      style={
+        isSelected
+          ? {
+              borderColor: style.accentColor,
+              boxShadow: `0 0 24px ${style.accentColor}28, 0 0 0 1px ${style.accentColor}18 inset`,
+            }
+          : undefined
+      }
+    >
+      {/* Selected badge */}
+      {isSelected && (
+        <div
+          className="absolute top-3 right-3 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider"
+          style={{
+            color: style.accentColor,
+            background: `${style.accentColor}18`,
+            border: `1px solid ${style.accentColor}35`,
+          }}
+        >
+          <CheckCircle2 className="w-3 h-3" />
+          {isThisPreviewing ? "Previewing…" : "Selected"}
+        </div>
+      )}
+
+      <ThumbnailStrip style={style} revealAfter={showAfter} />
+
+      <div className="space-y-0.5">
+        <h3
+          id={headingId}
+          className="text-[15px] font-bold text-white tracking-tight"
+        >
+          {style.name}
+        </h3>
+        <p className="text-[12px] text-muted-foreground leading-relaxed">
+          {style.description}
+        </p>
+      </div>
+
+      <div className="flex items-center gap-1.5 text-[11px] font-semibold text-muted-foreground">
+        <Clock className="w-3.5 h-3.5 shrink-0" />
+        <span>{formatDuration(style.avgDurationSeconds)} processing</span>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onSelect(style)}
+        disabled={disabled}
+        aria-pressed={isSelected}
+        aria-label={
+          quotaExhausted && !isSelected
+            ? `${style.name} style — quota exhausted, upgrade to use`
+            : `Select ${style.name} style`
+        }
+        className={[
+          "w-full py-3 rounded-xl font-bold text-[13px] transition-all duration-200",
+          "flex items-center justify-center gap-2",
+          "active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
+          isSelected
+            ? "border border-white/10 text-white hover:bg-white/[0.05]"
+            : "text-black hover:brightness-110 shadow-lg",
+        ].join(" ")}
+        style={
+          isSelected
+            ? undefined
+            : {
+                backgroundColor: style.accentColor,
+                boxShadow: `0 0 20px ${style.accentColor}40`,
+              }
+        }
+      >
+        {isThisPreviewing ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Generating preview…
+          </>
+        ) : isSelected ? (
+          <>
+            <Zap className="w-3.5 h-3.5" />
+            Apply style
+          </>
+        ) : quotaExhausted ? (
+          <>
+            <ArrowUpRight className="w-3.5 h-3.5" />
+            Upgrade to use
+          </>
+        ) : (
+          "Preview style"
+        )}
+      </button>
+    </article>
+  );
+}
+
+/* ─── Loading skeleton grid ──────────────────────────────────────────────────── */
+
+function StylePickerSkeleton() {
+  return (
+    <div className="space-y-4">
+      <QuotaBarSkeleton />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-4 rounded-[20px] p-5 border border-white/[0.05] bg-surface/40"
+            aria-hidden="true"
+          >
+            <Skeleton className="w-full h-[88px] rounded-[10px]" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+            <Skeleton className="h-3 w-1/4" />
+            <Skeleton className="w-full h-11 rounded-xl" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Error state ─────────────────────────────────────────────────────────────── */
+
+function StylePickerError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+      <p className="text-[14px] text-muted-foreground">
+        Failed to load transformation styles.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="flex items-center gap-2 px-4 py-2 rounded-xl border border-white/10 text-white text-[13px] font-bold hover:bg-white/[0.05] transition-all"
+      >
+        <RefreshCw className="w-3.5 h-3.5" />
+        Try again
+      </button>
+    </div>
+  );
+}
+
+/* ─── Main component ─────────────────────────────────────────────────────────── */
+
+/** Low-res preview simulation delay (ms). Replace with a real API call in production. */
+const PREVIEW_DELAY_MS = 1200;
+
+export default function StylePicker({
+  selectedStyleId = null,
+  onSelect,
+  disabled = false,
+  styles: stylesProp,
+  quota: quotaProp,
+}: StylePickerProps) {
+  const [styles, setStyles] = useState<TransformStyle[]>(stylesProp ?? []);
+  const [stylesLoading, setStylesLoading] = useState(!stylesProp);
+  const [stylesError, setStylesError] = useState(false);
+
+  const [quota, setQuota] = useState<QuotaInfo | null>(quotaProp ?? null);
+  const [quotaLoading, setQuotaLoading] = useState(!quotaProp);
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    selectedStyleId ?? null
+  );
+  const [previewingId, setPreviewingId] = useState<string | null>(null);
+
+  const uid = useId();
+
+  // Sync controlled selectedStyleId prop
+  useEffect(() => {
+    if (selectedStyleId !== undefined) {
+      setSelectedId(selectedStyleId ?? null);
+    }
+  }, [selectedStyleId]);
+
+  // ── Fetch styles ────────────────────────────────────────────────────────────
+  const fetchStyles = useCallback(async () => {
+    setStylesLoading(true);
+    setStylesError(false);
+    try {
+      const res = await fetch("/api/transform/styles");
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json();
+      setStyles(data.styles ?? []);
+    } catch {
+      setStylesError(true);
+    } finally {
+      setStylesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!stylesProp) fetchStyles();
+  }, [fetchStyles, stylesProp]);
+
+  useEffect(() => {
+    if (stylesProp) {
+      setStyles(stylesProp);
+      setStylesLoading(false);
+    }
+  }, [stylesProp]);
+
+  // ── Fetch quota ─────────────────────────────────────────────────────────────
+  const fetchQuota = useCallback(async () => {
+    setQuotaLoading(true);
+    try {
+      const res = await fetch("/api/transform");
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json();
+      setQuota({
+        remaining: data.quotaRemaining,
+        limit: data.quotaLimit,
+        resetAt: data.resetAt,
+        unlimited: data.unlimited ?? false,
+      });
+    } catch {
+      // Non-fatal: quota bar simply won't render
+    } finally {
+      setQuotaLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!quotaProp) fetchQuota();
+  }, [fetchQuota, quotaProp]);
+
+  useEffect(() => {
+    if (quotaProp) {
+      setQuota(quotaProp);
+      setQuotaLoading(false);
+    }
+  }, [quotaProp]);
+
+  // ── Derived state ───────────────────────────────────────────────────────────
+  const quotaExhausted =
+    quota !== null &&
+    !quota.unlimited &&
+    quota.remaining !== null &&
+    quota.remaining <= 0;
+
+  // ── Selection handler ───────────────────────────────────────────────────────
+  const handleSelect = useCallback(
+    (style: TransformStyle) => {
+      // Block if: globally disabled, another preview in-flight, or quota gone
+      if (disabled || previewingId || quotaExhausted) return;
+
+      // Already selected → confirm apply (non-preview)
+      if (selectedId === style.id) {
+        onSelect?.(style, false);
+        return;
+      }
+
+      setSelectedId(style.id);
+      setPreviewingId(style.id);
+      onSelect?.(style, true);
+
+      setTimeout(() => {
+        setPreviewingId(null);
+        onSelect?.(style, false);
+      }, PREVIEW_DELAY_MS);
+    },
+    [disabled, previewingId, quotaExhausted, selectedId, onSelect]
+  );
+
+  const loading = stylesLoading || quotaLoading;
+  if (loading) return <StylePickerSkeleton />;
+  if (stylesError) return <StylePickerError onRetry={fetchStyles} />;
+
+  return (
+    <section aria-label="AI transformation style picker" className="space-y-4">
+      {/* Quota bar — always rendered once quota is known */}
+      {quota && <QuotaBar quota={quota} />}
+
+      {/* Upgrade CTA banner when exhausted (prominent, above the grid) */}
+      {quotaExhausted && (
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 px-4 py-3 rounded-xl bg-brand/[0.07] border border-brand/20">
+          <div className="space-y-0.5">
+            <p className="text-[13px] font-bold text-white">
+              You&apos;ve used all your transforms this month
+            </p>
+            <p className="text-[12px] text-muted-foreground">
+              Upgrade to Pro (50/month) or Enterprise (unlimited) to keep
+              creating.
+            </p>
+          </div>
+          <Link
+            href="/settings?tab=billing"
+            className="shrink-0 flex items-center gap-1.5 px-4 py-2 rounded-xl bg-brand hover:bg-brand-hover text-black text-[13px] font-bold transition-all active:scale-[0.98]"
+          >
+            <ArrowUpRight className="w-3.5 h-3.5" />
+            Upgrade Plan
+          </Link>
+        </div>
+      )}
+
+      {/* Style grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {styles.map((style) => {
+          const isSelected = selectedId === style.id;
+          // When quota is exhausted, only disable cards that aren't already
+          // selected so the user can still see their chosen style.
+          const cardDisabled =
+            disabled ||
+            (previewingId !== null && previewingId !== style.id) ||
+            (quotaExhausted && !isSelected);
+
+          return (
+            <StyleCard
+              key={style.id}
+              style={style}
+              isSelected={isSelected}
+              isPreviewing={previewingId === style.id}
+              disabled={cardDisabled}
+              quotaExhausted={quotaExhausted}
+              onSelect={handleSelect}
+              headingId={`${uid}-${style.id}`}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
closes #689 
closes #696 
closes #699 
closes #700 

Summary of what was done:

#689:
What was implemented
platformConnections.ts
 — the platform_connections table equivalent

Map-based in-memory store keyed by userId::platform (matches the project's no-DB pattern used by jobStore)
upsertConnection, getConnections, deleteConnection, hasConnection helpers
Full PlatformConnection type: userId, platform, accessToken, refreshToken, username, connectedAt
route.ts
 — the two new endpoints

GET /api/platforms/connections — returns all connections for the authed user; strips accessToken/refreshToken from the response so tokens never reach the client
DELETE /api/platforms/connections?platform=tiktok — removes a specific connection; validates the platform name; returns 404 if not found
auth.ts
 — upsert on every OAuth sign-in

Added TikTokProvider alongside Google and Apple
The jwt callback calls upsertConnection(...) whenever account is present (i.e. on actual sign-in, not on every session refresh)
Google gets the youtube.readonly scope so the connection is meaningful for YouTube content sync
page.tsx
 — reads from the API, not from session.user.provider

Fetches GET /api/platforms/connections on mount via fetchConnections()
Each platform card's status, username, onConnect, and onDisconnect are all derived from the live connections array
Connecting calls signIn(provider) then re-fetches; disconnecting calls DELETE /api/platforms/connections?platform=...
Instagram and Twitter are marked isComingSoon: true until those OAuth apps are configured
Loading/connecting/disconnecting states are tracked per-platform so cards don't all spin together
.env.example — documents the required secrets: NEXTAUTH_SECRET, NEXTAUTH_URL, GOOGLE_CLIENT_ID/SECRET, APPLE_*, TIKTOK_CLIENT_ID/SECRET

#696:
Here's a full walkthrough of what was built:

route.ts
GET /api/transform/styles returns the 6 V1 style presets, each with id, name, thumbnailBefore, thumbnailAfter, avgDurationSeconds, description, and accentColor. The TransformStyle type is exported so the component imports it directly from the API layer — single source of truth.

StylePicker.tsx
A few design decisions worth noting:

Preview flow — clicking "Preview style" on an unselected card sets it to a previewing state for PREVIEW_DELAY_MS (1200ms, replace with a real API call). During that window the button shows a spinner and "Generating preview…", and the other cards are disabled so the user can't stack requests. After the delay the "after" thumbnail cross-fades in and onSelect(style, false) fires to signal the preview is done. Clicking "Apply style" on an already-selected card fires onSelect(style, false) immediately.

Thumbnail strip — the before/after pair sits inside a two-column strip with a thin divider. Images load lazily and fall back to a coloured placeholder (using accentColor) when the asset isn't found, so the component works in Storybook without real video thumbnails.

Selected state — the card border switches to [2px] with the style's accentColor ring and a subtle inset glow, matching the brand glow pattern from existing cards.

Disabled state — the disabled prop (e.g. full processing running) greys out unselected cards and blocks interaction. The selected card stays visually prominent so the user knows which style was chosen.

Accessibility — each card is an <article> with aria-labelledby pointing to the style name, aria-selected on the article, and aria-pressed on the button. The grid has an aria-label region.

StylePicker.stories.tsx
Stories cover: Default, WithSelection, Disabled, SelectedAndDisabled, Loading (skeleton), AllStyles (full grid), and one story per individual style (AnimeStyle … NeonNoirStyle). All stories pass the fixture data directly via the styles prop so no real network request is made. The Loading story overrides styles: undefined with a never-resolving fetch mock to keep the skeleton visible.

#699:

clip.ts
 — shared type definitions
ClipTransformation captures { style, styleLabel, resultUrl, jobId, createdAt } as specified. Clip replaces the local NFTItem interfaces that were scattered across NFTGrid and NFTCard — one source of truth consumed by the API route, the grid, the card, and the form.

route.ts
 — GET /api/clips
Returns all clips with their full transformations array. Accepts an optional ?status= filter so NFTGrid can request only the clips relevant to the active vault tab. Pre-seeded with 8 clips: several have 1–3 transformations already attached so the UI is immediately demonstrable.

NFTCard.tsx
 — transform badge + download
Three additions to the card:

Thumbnail overlay chip (bottom-right) — shows the most recent style name or "N styles" when multiple transformations exist, using the style's accent colour. Visible at a glance without needing to expand anything.
Badge row (below the rarity badge) — TransformBadge chip with a wand icon.
Collapsible transformation history panel — toggled by a "N transformations" button. Expands into a list where each row shows style name, date, and a Download button that triggers an MP4 download of that variant. The original video also gets a download row at the bottom of the list.
The onMintSelect callback fires with { id, versionUrl, isTransformed, style } so the vault page knows exactly which version the user wants to mint.

NFTGrid.tsx
 — fetches from API
Replaces the broken mockNFTData reference (the comment placeholder // ... mock data ... would have crashed at runtime) with a real fetch("/api/clips") call. Added onMintSelect prop that passes the clip's transformation list up to the vault page.

MintConfigForm.tsx
 — version picker
When selectedClip is provided the form renders a VersionPicker above the fields — a radio-button list showing the original clip plus every transformed variant. Selecting a different version fires onVersionChange so the vault page can update its state. A confirmation chip below the picker always shows which version is currently queued: Minting: Neon Noir version of "Epic Gaming Moment" or Minting: Original "Travel Vlog".

page.tsx
 — wiring
pendingMint state holds the selected clip version. handleMintSelect is passed into NFTGrid and sets pendingMint + opens the mint panel automatically. The VersionPicker's onVersionChange merges the new version choice back into pendingMint so the form stays in sync.

#700:
transformQuota.ts
 — the quota engine
Pure in-memory store keyed by userId. consumeQuota is the only function that mutates state — it's an atomic check-and-decrement so there's no race between reading and writing. nextResetDate computes 1st of next month 00:00 UTC using Date.UTC so it's timezone-safe. isExpired compares Date.now() against the stored resetAt and auto-rolls over on the next call after a period boundary — no cron job needed. Enterprise gets Infinity throughout so none of the comparison logic needs special-casing on the caller side.

route.ts
 — two endpoints
POST /api/transform — validates clipId + style, calls consumeQuota, returns 429 { code: "QUOTA_EXCEEDED", resetAt, upgradePath } when exhausted or 202 { jobId, quotaRemaining } when allowed. The upgradePath field gives the frontend a direct link to send users to.

GET /api/transform — quota status without consuming a credit. The StylePicker calls this on mount to populate its bar without needing a full user-profile fetch.

Both routes read plan from session.user.plan and fall back to "free" if absent, matching the existing pattern in auth.ts where extra fields are set on session.user via as any.

types.ts
 — UserProfile extended
Added transformQuotaRemaining: number | null (null = unlimited) and transformQuotaResetAt: string | null to UserProfile. These are the exact fields the AC specified plus a null sentinel for enterprise, which is cleaner than using Infinity in a serialisable type.

api.ts
 — mock profile updated
MOCK_PROFILE is populated with the new fields. fetchUserFromAPI recomputes quota on every call so the value stays in sync with what POST /api/transform has consumed in-process — both functions share the same transformQuota store.

StylePicker.tsx
 — quota UI
Two new visual elements:

QuotaBar — sits above the style grid. Shows a coloured progress bar (green → yellow at 60% consumed → red at 90%), the remaining count, and the reset date. For enterprise it shows an infinity icon and "Unlimited transforms". When remaining === 0 the bar text turns red, the bar itself is full red, and an inline "Upgrade plan to continue" link appears.

Upgrade CTA banner — a second, more prominent element shown only when quotaExhausted. Explains the situation in plain language and has a solid brand-coloured "Upgrade Plan" button linking to /settings?tab=billing.

Card-level behaviour — when quota is exhausted, unselected cards get cardDisabled = true and their button label switches to "Upgrade to use" with an ArrowUpRight icon. An already-selected card is not disabled so the user can still see their chosen style and read the processing time.

The component accepts a quota?: QuotaInfo prop for Storybook/testing — when provided it skips the GET /api/transform fetch entirely.

StylePicker.stories.tsx — quota stories
Added 7 new quota-specific stories: QuotaFreePlanFull, QuotaProPartial, QuotaProLow, QuotaExhausted, QuotaExhaustedWithSelection, QuotaUnlimited, and the updated Loading story which now also mocks the GET /api/transform fetch. All existing per-style stories are preserved and receive quota: QUOTA_PRO_PARTIAL so they render the bar without making a real request.