### PR TITLE
perf: lazy-load dashboard components, loading states, branded 404/error, logger drain

### DIFF
--- a/app/(dashboard)/activity/loading.tsx
+++ b/app/(dashboard)/activity/loading.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function Loading() {
+  return (
+    <div className="dashboard-main space-y-6 max-w-[1200px] mx-auto w-full">
+      <div className="flex items-center gap-3">
+        <Skeleton className="w-10 h-10 rounded-xl" />
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-40 rounded-lg" />
+          <Skeleton className="h-4 w-64 rounded-lg" />
+        </div>
+      </div>
+
+      <div className="bg-surface border border-border rounded-[24px] p-5 sm:p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-6 w-6 rounded-lg" />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-7 w-12 rounded-lg" />
+          <Skeleton className="h-7 w-20 rounded-lg" />
+          <Skeleton className="h-7 w-16 rounded-lg" />
+        </div>
+
+        <div className="space-y-3">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="flex items-center gap-3 p-3 rounded-xl border border-border bg-surface-hover/50">
+              <Skeleton className="w-8 h-8 rounded-lg shrink-0" />
+              <div className="flex-1 space-y-2">
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-3 w-32" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import StatCard from "@/components/dashboard/StatCard";
-import PlatformDistribution from "@/components/dashboard/PlatformDistribution";
 import AIInsightCard from "@/components/dashboard/AIInsightCard";
 import ProjectCard from "@/components/dashboard/ProjectCard";
 import EarningsSummaryCards from "@/components/dashboard/EarningsSummaryCards";
@@ -16,6 +15,7 @@ import DashboardPageHeader from "./DashboardPageHeader";
 
 // Lazy-load heavy client components for better performance
 const RevenueChart = dynamic(() => import("@/components/dashboard/RevenueChart"), {
+  ssr: false,
   loading: () => (
     <div className="bg-surface border border-border rounded-[24px] p-8 h-[300px] flex items-center justify-center">
       <Skeleton className="w-full h-full" />
@@ -24,6 +24,7 @@ const RevenueChart = dynamic(() => import("@/components/dashboard/RevenueChart")
 });
 
 const SendPaymentForm = dynamic(() => import("@/components/SendPaymentForm"), {
+  ssr: false,
   loading: () => (
     <div className="bg-surface border border-border rounded-[24px] p-8 h-[300px] flex items-center justify-center">
       <Skeleton className="w-full h-full" />
@@ -32,8 +33,18 @@ const SendPaymentForm = dynamic(() => import("@/components/SendPaymentForm"), {
 });
 
 const WalletHealthCard = dynamic(() => import("@/components/wallet/WalletHealthCard"), {
+  ssr: false,
   loading: () => (
     <div className="bg-surface border border-border rounded-[24px] p-8 h-[200px] flex items-center justify-center">
+      <Skeleton className="w-full h-full" />
+    </div>
+  ),
+});
+
+const PlatformDistribution = dynamic(() => import("@/components/dashboard/PlatformDistribution"), {
+  ssr: false,
+  loading: () => (
+    <div className="bg-surface border border-border rounded-[24px] p-6 h-[300px] flex items-center justify-center">
       <Skeleton className="w-full h-full" />
     </div>
   ),

--- a/app/(dashboard)/transform/[id]/loading.tsx
+++ b/app/(dashboard)/transform/[id]/loading.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background text-white flex flex-col font-sans relative overflow-hidden">
+      <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute top-[-10%] left-1/2 -translate-x-1/2 w-[1000px] h-[600px] bg-brand/5 blur-[120px] rounded-full" />
+      </div>
+
+      <main className="flex-1 flex flex-col items-center justify-center px-6 py-16 relative z-10">
+        <div className="w-full max-w-3xl space-y-10">
+          <div className="flex flex-col items-center text-center gap-5">
+            <Skeleton className="w-20 h-20 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-72 rounded-xl" />
+              <Skeleton className="h-4 w-56 rounded-lg" />
+            </div>
+          </div>
+
+          <div className="bg-surface border border-white/5 rounded-3xl p-8 space-y-7">
+            <div className="flex items-center gap-4">
+              <Skeleton className="w-20 h-14 rounded-xl" />
+              <div className="min-w-0 space-y-2">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-48" />
+              <Skeleton className="h-3 w-full rounded-full" />
+              <Skeleton className="h-3 w-32 ml-auto" />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(dashboard)/vault/loading.tsx
+++ b/app/(dashboard)/vault/loading.tsx
@@ -3,41 +3,34 @@ import Skeleton from "@/components/ui/Skeleton";
 
 export default function Loading() {
   return (
-    <div className="flex min-h-screen bg-background text-white font-sans overflow-hidden">
-      <div className="hidden lg:flex flex-col sticky top-0 h-screen py-10 pl-10 shrink-0 w-[240px]">
-        <div className="space-y-6">
-          <div>
-            <Skeleton className="h-4 w-32 mb-4" />
-            <Skeleton className="h-10 w-full rounded-xl mb-2" />
-            <Skeleton className="h-10 w-full rounded-xl mb-2" />
-            <Skeleton className="h-10 w-full rounded-xl mb-2" />
+    <div className="dashboard-main space-y-8 max-w-full mx-auto w-full">
+      <div className="px-6 sm:px-8 pt-2">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-10 w-64 rounded-xl" />
+          <Skeleton className="h-4 w-80 rounded-lg" />
+        </div>
+      </div>
+      <div className="flex gap-6 px-6 sm:px-8 pb-8">
+        <div className="hidden lg:block w-64 shrink-0">
+          <Skeleton className="h-8 w-32 mb-4" />
+          <Skeleton className="h-10 w-full rounded-xl mb-2" />
+          <Skeleton className="h-10 w-full rounded-xl mb-2" />
+          <Skeleton className="h-10 w-full rounded-xl mb-2" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[1, 2].map((i) => (
+              <div key={i} className="bg-surface border border-border rounded-[24px] p-4 flex flex-col gap-4">
+                <Skeleton className="w-full aspect-square rounded-xl" />
+                <div className="space-y-2">
+                  <Skeleton className="h-5 w-3/4" />
+                  <Skeleton className="h-4 w-1/2" />
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </div>
-      <main className="flex-1 flex flex-col h-screen relative z-10 px-4 sm:px-6 lg:px-10 xl:px-16 overflow-hidden min-w-0 pt-6">
-        <div className="flex flex-col gap-2 mb-8">
-          <Skeleton className="h-10 w-48 rounded-xl" />
-          <Skeleton className="h-4 w-72" />
-        </div>
-        <div className="flex gap-6">
-          <div className="flex-1 min-w-0">
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-                <div key={i} className="bg-surface border border-border rounded-xl p-3 flex flex-col gap-3">
-                  <Skeleton className="w-full aspect-square rounded-lg" />
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-3/4" />
-                    <Skeleton className="h-3 w-1/2" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-          <div className="hidden lg:block w-96 shrink-0">
-            <Skeleton className="h-[500px] w-full rounded-[20px]" />
-          </div>
-        </div>
-      </main>
     </div>
   );
 }

--- a/app/(dashboard)/wallet/loading.tsx
+++ b/app/(dashboard)/wallet/loading.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function Loading() {
+  return (
+    <div className="dashboard-main space-y-8 max-w-[1400px] mx-auto w-full">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-64 rounded-xl" />
+          <Skeleton className="h-4 w-40 rounded-lg" />
+        </div>
+        <Skeleton className="h-10 w-24 rounded-xl" />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Balance hero */}
+        <div className="lg:col-span-2 bg-surface border border-border rounded-[24px] p-6 flex flex-col gap-4">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-12 w-48" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+
+        {/* Donut */}
+        <div className="bg-surface border border-border rounded-[24px] p-6 flex flex-col items-center gap-4">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="w-32 h-32 rounded-full" />
+        </div>
+      </div>
+
+      {/* Asset list */}
+      <div className="bg-surface border border-border rounded-[24px] p-6 space-y-4">
+        <Skeleton className="h-5 w-32" />
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex items-center gap-4 p-3 rounded-xl border border-border">
+            <Skeleton className="w-8 h-8 rounded-full shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,2 +1,68 @@
-"use client";
-export { default } from "@/components/ui/ErrorUI";
+'use client';
+
+import React from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+
+interface RootErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+function BrandHeader() {
+  return (
+    <header className="w-full flex items-center justify-between px-6 py-4 bg-surface/50 backdrop-blur-sm border-b border-white/5">
+      <div className="flex items-center gap-2">
+        <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand to-brand/60 flex items-center justify-center">
+          <span className="text-white font-bold text-sm">C</span>
+        </div>
+        <span className="text-white font-semibold text-lg">ClipCash</span>
+      </div>
+    </header>
+  );
+}
+
+export default function RootError({ error, reset }: RootErrorProps) {
+  const errorId = error.digest || Sentry.captureException(error);
+
+  React.useEffect(() => {
+    if (!error.digest) {
+      Sentry.captureException(error);
+    }
+  }, [error, error.digest]);
+
+  return (
+    <div className="min-h-screen bg-background text-white font-sans flex flex-col relative overflow-hidden">
+      <BrandHeader />
+
+      <main className="flex-1 flex flex-col items-center justify-center px-6 py-20 relative z-10">
+        <div className="w-full max-w-md space-y-6 text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+            <AlertCircle className="h-8 w-8 text-destructive" />
+          </div>
+
+          <div className="space-y-2">
+            <h2 className="text-2xl font-bold text-foreground">Something went wrong</h2>
+            <p className="text-sm text-muted-foreground max-w-md">
+              An unexpected error occurred. Please try again, or contact support if the problem persists.
+            </p>
+          </div>
+
+          {errorId && (
+            <p className="text-xs text-muted-foreground">
+              Error ID: <code className="bg-muted px-1.5 py-0.5 rounded font-mono">{errorId}</code>
+            </p>
+          )}
+
+          <button
+            onClick={reset}
+            className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-lg transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try Again
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/lib/logger.ts
+++ b/app/lib/logger.ts
@@ -4,44 +4,162 @@ type LogLevel = "debug" | "info" | "warn" | "error";
 
 const isProduction = process.env.NODE_ENV === "production";
 
+interface LogEntry {
+  level: LogLevel;
+  message: string;
+  timestamp: string;
+  service: string;
+  traceId?: string;
+  [key: string]: any;
+}
+
+let drainUrl: string | undefined;
+let batch: LogEntry[] = [];
+let batchTimer: ReturnType<typeof setTimeout> | null = null;
+const MAX_BATCH_SIZE = 50;
+const MAX_BATCH_DELAY_MS = 100;
+
+function getTraceId(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  // @ts-ignore - custom request headers may be attached by runtime/infra
+  return (
+    // @ts-ignore
+    window.__NEXT_DATA?.headers?.["x-vercel-id"] ||
+    // @ts-ignore
+    window.__NEXT_DATA?.headers?.["x-request-id"] ||
+    undefined
+  );
+}
+
+function serializeArgs(args: any[]): string {
+  return args
+    .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+    .join(" ");
+}
+
+function createLogEntry(level: LogLevel, args: any[]): LogEntry {
+  const entry: LogEntry = {
+    level,
+    message: serializeArgs(args),
+    timestamp: new Date().toISOString(),
+    service: "clipcash-frontend",
+    traceId: getTraceId(),
+  };
+
+  const error = args.find((arg) => arg instanceof Error);
+  if (error && typeof error === "object") {
+    entry.error = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return entry;
+}
+
+function flushBatch() {
+  if (!drainUrl || batch.length === 0) return;
+
+  const entries = batch.splice(0, batch.length);
+  const payload = JSON.stringify(entries);
+
+  if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+    const blob = new Blob([payload], { type: "application/json" });
+    navigator.sendBeacon(drainUrl, blob);
+  } else {
+    fetch(drainUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {
+      // swallow network errors for logging
+    });
+  }
+}
+
+function scheduleFlush() {
+  if (batchTimer) return;
+  batchTimer = setTimeout(() => {
+    batchTimer = null;
+    flushBatch();
+  }, MAX_BATCH_DELAY_MS);
+}
+
+function drain(entry: LogEntry) {
+  if (!drainUrl) return;
+  batch.push(entry);
+  if (batch.length >= MAX_BATCH_SIZE) {
+    if (batchTimer) {
+      clearTimeout(batchTimer);
+      batchTimer = null;
+    }
+    flushBatch();
+  } else {
+    scheduleFlush();
+  }
+}
+
+function consoleFallback(level: LogLevel, args: any[]) {
+  const method =
+    level === "debug" ? console.debug :
+    level === "warn" ? console.warn :
+    level === "error" ? console.error :
+    console.info;
+  method(...args);
+}
+
+function sendToSentry(level: LogLevel, args: any[]) {
+  const message = serializeArgs(args);
+  if (level === "error") {
+    const error = args.find((arg) => arg instanceof Error);
+    if (error) {
+      Sentry.captureException(error);
+    }
+    Sentry.addBreadcrumb({ message, level: "error" });
+  } else if (level === "warn") {
+    Sentry.addBreadcrumb({ message, level: "warning" });
+  } else {
+    Sentry.addBreadcrumb({ message, level: "info" });
+  }
+}
+
+if (typeof process !== "undefined") {
+  drainUrl = process.env.LOG_DRAIN_URL;
+}
+
 export const logger = {
   debug: (...args: any[]) => {
     if (!isProduction) {
-      console.debug(...args);
+      consoleFallback("debug", args);
     }
   },
   info: (...args: any[]) => {
+    const entry = createLogEntry("info", args);
     if (isProduction) {
-      Sentry.addBreadcrumb({
-        message: args.map(arg => (typeof arg === "string" ? arg : JSON.stringify(arg))).join(" "),
-        level: "info",
-      });
+      sendToSentry("info", args);
+      drain(entry);
     } else {
-      console.info(...args);
+      consoleFallback("info", args);
     }
   },
   warn: (...args: any[]) => {
+    const entry = createLogEntry("warn", args);
     if (isProduction) {
-      Sentry.addBreadcrumb({
-        message: args.map(arg => (typeof arg === "string" ? arg : JSON.stringify(arg))).join(" "),
-        level: "warning",
-      });
+      sendToSentry("warn", args);
+      drain(entry);
     } else {
-      console.warn(...args);
+      consoleFallback("warn", args);
     }
   },
   error: (...args: any[]) => {
+    const entry = createLogEntry("error", args);
     if (isProduction) {
-      const error = args.find(arg => arg instanceof Error);
-      if (error) {
-        Sentry.captureException(error);
-      }
-      Sentry.addBreadcrumb({
-        message: args.map(arg => (typeof arg === "string" ? arg : JSON.stringify(arg))).join(" "),
-        level: "error",
-      });
+      sendToSentry("error", args);
+      drain(entry);
     } else {
-      console.error(...args);
+      consoleFallback("error", args);
     }
   },
 };

--- a/stories/NotFound.stories.tsx
+++ b/stories/NotFound.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import NotFound from '@/app/not-found';
+
+const meta = {
+  title: 'App/NotFound',
+  component: NotFound,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof NotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
Closes #748
Closes #747
Closes #746
Closes #749

Changes:
- Lazy-load RevenueChart, SendPaymentForm, WalletHealthCard, PlatformDistribution with dynamic(..., { ssr: false })
- Add loading.tsx skeletons for dashboard, projects, earnings, vault, wallet, activity, transform/[id]
- Add branded app/not-found.tsx and app/error.tsx with dark theme, logo, retry, error ID
- Add Storybook story stories/NotFound.stories.tsx
- Add optional log drain support in app/lib/logger.ts (LOG_DRAIN_URL) with batched JSON logs