### PR TITLE
feat: add clip export in multiple formats (#823)

### DIFF
--- a/app/(dashboard)/projects/page.tsx
+++ b/app/(dashboard)/projects/page.tsx
@@ -13,11 +13,13 @@ import { useToast } from "@/hooks/useToast";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { useFilterQueryState } from "@/hooks/useFilterQueryState";
 import { useBatchTransform } from "@/app/hooks/useBatchTransform";
+import { useUserStore, selectUserPlan } from "@/app/store/userStore";
 
 const RECOMMENDATION_THRESHOLD = 90;
 
 export default function ProjectsPage() {
   const { showToast, ToastEl } = useToast();
+  const userPlan = useUserStore(selectUserPlan);
   const { 
     state: selectedIds, 
     set: setSelectedIds, 
@@ -397,6 +399,7 @@ export default function ProjectsPage() {
                 loadingNextPage={loadingNextPage}
                 onLoadMore={handleLoadMore}
                 hasMore={fetchedClips.length < totalClips}
+                userPlan={userPlan}
               />
             </div>
             

--- a/app/api/clips/[id]/exports/route.ts
+++ b/app/api/clips/[id]/exports/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/app/api/jobs/shared/authGuard";
+import { clipsStore } from "@/app/api/clips/clipsStore";
+import { exportsStore } from "@/app/api/exports/exportsStore";
+import { jobStore } from "@/app/api/jobs/shared/jobStore";
+import { buildObjectUrl } from "@/app/lib/cloudStorage";
+import type { ApiResponse } from "@/app/api/types";
+
+/**
+ * GET /api/clips/:id/exports
+ *
+ * List all export versions for a clip with status and download URLs.
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const { id: clipId } = await context.params;
+
+  clipsStore.getClipsForUser(userId);
+  const unowned = clipsStore.findUnownedClipIds(userId, [clipId]);
+  if (unowned.length > 0) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 403 });
+  }
+
+  const exports = exportsStore.getExportsForClip(clipId, userId);
+
+  const synced = await Promise.all(
+    exports.map(async (exp) => {
+      const job = await jobStore.get(exp.jobId);
+      let status = exp.status;
+      let downloadUrl = exp.downloadUrl;
+      let errorMessage = exp.errorMessage;
+      let completedAt = exp.completedAt;
+
+      if (job) {
+        if (job.status === "processing" && status === "queued") {
+          status = "processing";
+        }
+        if (job.status === "complete" && status !== "complete") {
+          status = "complete";
+          downloadUrl = buildObjectUrl(exp.objectKey);
+          completedAt = new Date().toISOString();
+          exportsStore.updateByJobId(exp.jobId, { status, downloadUrl, completedAt });
+        }
+        if (job.status === "error") {
+          status = "error";
+          errorMessage = job.errorMessage ?? "Transcoding failed";
+          exportsStore.updateByJobId(exp.jobId, { status, errorMessage });
+        }
+      }
+
+      if (status === "complete" && !downloadUrl) {
+        downloadUrl = buildObjectUrl(exp.objectKey);
+      }
+
+      return {
+        id: exp.id,
+        clipId: exp.clipId,
+        format: exp.format,
+        aspectRatio: exp.aspectRatio,
+        quality: exp.quality,
+        status,
+        downloadUrl: status === "complete" ? downloadUrl : null,
+        errorMessage: status === "error" ? errorMessage : null,
+        createdAt: exp.createdAt,
+        completedAt: completedAt ?? null,
+      };
+    }),
+  );
+
+  const body: ApiResponse<{ exports: typeof synced }> = {
+    data: { exports: synced },
+    error: null,
+  };
+
+  return NextResponse.json(body);
+}

--- a/app/api/clips/[id]/transcode/route.ts
+++ b/app/api/clips/[id]/transcode/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { checkCsrf } from "@/app/lib/csrf";
+import { applyRateLimit } from "@/app/lib/serverRateLimit";
+import { requireAuth } from "@/app/api/jobs/shared/authGuard";
+import { parseRequestJson } from "@/app/lib/parseRequestJson";
+import { dispatchJob } from "@/app/lib/aiBackend";
+import { logger } from "@/app/lib/logger";
+import { isExportQualityAllowed } from "@/app/lib/planLimits";
+import { buildExportObjectKey } from "@/app/lib/cloudStorage";
+import { prisma } from "@/app/lib/prisma";
+import { clipsStore } from "@/app/api/clips/clipsStore";
+import { exportsStore } from "@/app/api/exports/exportsStore";
+import { jobStore } from "@/app/api/jobs/shared/jobStore";
+import { transcodeBodySchema } from "@/app/api/schemas/index";
+import type { ApiResponse } from "@/app/api/types";
+
+/**
+ * POST /api/clips/:id/transcode
+ *
+ * Dispatch an asynchronous transcoding job for the clip.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const rateLimited = await applyRateLimit(request, { limit: 20, windowMs: 60_000 });
+  if (rateLimited) return rateLimited;
+
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const { id: clipId } = await context.params;
+
+  clipsStore.getClipsForUser(userId);
+  const unowned = clipsStore.findUnownedClipIds(userId, [clipId]);
+  if (unowned.length > 0) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 403 });
+  }
+
+  const parsedBody = await parseRequestJson(request);
+  if (!parsedBody.ok) return parsedBody.response;
+
+  const bodyValidation = transcodeBodySchema.safeParse(parsedBody.body);
+  if (!bodyValidation.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: bodyValidation.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const { format, aspectRatio, quality } = bodyValidation.data;
+
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  const plan = user?.plan ?? "free";
+
+  if (!isExportQualityAllowed(plan, quality)) {
+    return NextResponse.json(
+      {
+        error: "Plan restriction",
+        message: "Free plan supports 720p exports only. Upgrade to Pro for 1080p.",
+      },
+      { status: 403 },
+    );
+  }
+
+  const jobId = `transcode_${randomUUID().replace(/-/g, "")}`;
+  const exportRecord = exportsStore.createExport({
+    clipId,
+    userId,
+    jobId,
+    format,
+    aspectRatio,
+    quality,
+    objectKey: "",
+  });
+
+  const objectKey = buildExportObjectKey(clipId, format, aspectRatio, quality, exportRecord.id);
+  exportsStore.updateById(exportRecord.id, { objectKey });
+
+  const base =
+    process.env.NEXTAUTH_URL?.replace(/\/$/, "") ??
+    `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const callbackUrl = `${base}/api/jobs/${jobId}/callback`;
+  const sourceClipKey = `uploads/${clipId}`;
+
+  await jobStore.set(jobId, {
+    id: jobId,
+    userId,
+    status: "queued",
+    progress: 0,
+    momentsFound: 0,
+    estimatedSecondsRemaining: 120,
+    createdAt: Date.now(),
+  });
+
+  const dispatchResult = await dispatchJob({
+    jobId,
+    userId,
+    objectKey: sourceClipKey,
+    contentType: "video/mp4",
+    filename: `${clipId}.mp4`,
+    callbackUrl,
+    sourceClipKey,
+    jobType: "transcode",
+    transcodeOptions: {
+      format,
+      aspectRatio,
+      quality,
+      outputObjectKey: objectKey,
+    },
+  });
+
+  if (!dispatchResult.dispatched) {
+    logger.warn(
+      `[transcode] Dispatch failed for job ${jobId}: ${dispatchResult.reason}`,
+    );
+  }
+
+  const body: ApiResponse<{
+    exportId: string;
+    jobId: string;
+    clipId: string;
+    format: string;
+    aspectRatio: string;
+    quality: string;
+    status: string;
+    dispatched: boolean;
+  }> = {
+    data: {
+      exportId: exportRecord.id,
+      jobId,
+      clipId,
+      format,
+      aspectRatio,
+      quality,
+      status: "queued",
+      dispatched: dispatchResult.dispatched,
+    },
+    error: null,
+  };
+
+  return NextResponse.json(body, { status: 201 });
+}

--- a/app/api/exports/exportsStore.ts
+++ b/app/api/exports/exportsStore.ts
@@ -1,0 +1,68 @@
+export type ExportFormat = "mp4" | "webm";
+export type ExportAspectRatio = "9:16" | "1:1" | "16:9";
+export type ExportQuality = "720p" | "1080p";
+export type ExportStatus = "queued" | "processing" | "complete" | "error";
+
+export interface ClipExport {
+  id: string;
+  clipId: string;
+  userId: string;
+  jobId: string;
+  format: ExportFormat;
+  aspectRatio: ExportAspectRatio;
+  quality: ExportQuality;
+  status: ExportStatus;
+  objectKey: string;
+  downloadUrl?: string;
+  errorMessage?: string;
+  createdAt: string;
+  completedAt?: string;
+}
+
+class ExportsStore {
+  private exports: ClipExport[] = [];
+
+  createExport(data: Omit<ClipExport, "id" | "createdAt" | "status">): ClipExport {
+    const record: ClipExport = {
+      ...data,
+      id: `export_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      status: "queued",
+      createdAt: new Date().toISOString(),
+    };
+    this.exports.push(record);
+    return record;
+  }
+
+  getExportsForClip(clipId: string, userId: string): ClipExport[] {
+    return this.exports
+      .filter((e) => e.clipId === clipId && e.userId === userId)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }
+
+  getByJobId(jobId: string): ClipExport | undefined {
+    return this.exports.find((e) => e.jobId === jobId);
+  }
+
+  updateById(
+    id: string,
+    update: Partial<Pick<ClipExport, "objectKey" | "status" | "downloadUrl" | "errorMessage" | "completedAt">>,
+  ): ClipExport | undefined {
+    const index = this.exports.findIndex((e) => e.id === id);
+    if (index === -1) return undefined;
+    this.exports[index] = { ...this.exports[index], ...update };
+    return this.exports[index];
+  }
+
+  updateByJobId(
+    jobId: string,
+    update: Partial<Pick<ClipExport, "status" | "downloadUrl" | "errorMessage" | "completedAt" | "objectKey">>,
+  ): ClipExport | undefined {
+    const index = this.exports.findIndex((e) => e.jobId === jobId);
+    if (index === -1) return undefined;
+
+    this.exports[index] = { ...this.exports[index], ...update };
+    return this.exports[index];
+  }
+}
+
+export const exportsStore = new ExportsStore();

--- a/app/api/schemas/exports.schema.ts
+++ b/app/api/schemas/exports.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const transcodeBodySchema = z.object({
+  format: z.enum(["mp4", "webm"]),
+  aspectRatio: z.enum(["9:16", "1:1", "16:9"]),
+  quality: z.enum(["720p", "1080p"]),
+});
+
+export type TranscodeBody = z.infer<typeof transcodeBodySchema>;

--- a/app/api/schemas/index.ts
+++ b/app/api/schemas/index.ts
@@ -10,3 +10,4 @@ export * from "./clips.schema";
 export * from "./user.schema";
 export * from "./transform.schema";
 export * from "./billing.schema";
+export * from "./exports.schema";

--- a/app/lib/aiBackend.ts
+++ b/app/lib/aiBackend.ts
@@ -60,6 +60,15 @@ export interface DispatchJobPayload {
    * Only populated when transformStyle === "anime".
    */
   transformOptions?: AnimeTransformOptions;
+  /** Job type discriminator for the AI backend. */
+  jobType?: "clip" | "transform" | "transcode" | "caption";
+  /** Transcode export settings when jobType === "transcode". */
+  transcodeOptions?: {
+    format: "mp4" | "webm";
+    aspectRatio: "9:16" | "1:1" | "16:9";
+    quality: "720p" | "1080p";
+    outputObjectKey: string;
+  };
 }
 
 /**

--- a/app/lib/cloudStorage.ts
+++ b/app/lib/cloudStorage.ts
@@ -95,6 +95,41 @@ const KEY_PREFIX = process.env.CLOUD_STORAGE_KEY_PREFIX ?? "uploads/";
 const QUARANTINE_PREFIX = process.env.VIRUS_SCAN_QUARANTINE_PREFIX ?? "uploads/quarantine/";
 /** Prefix used for AI-transformed output files, kept separate from raw uploads. */
 export const TRANSFORMS_PREFIX = "transforms/";
+/** Prefix used for transcoded clip exports (multi-format / aspect-ratio outputs). */
+export const EXPORTS_PREFIX = "exports/";
+
+/**
+ * Build the S3 object key for a transcoded export.
+ */
+export function buildExportObjectKey(
+  clipId: string,
+  format: string,
+  aspectRatio: string,
+  quality: string,
+  exportId: string,
+): string {
+  const safeRatio = aspectRatio.replace(":", "x");
+  return `${EXPORTS_PREFIX}${clipId}/${exportId}_${safeRatio}_${quality}.${format}`;
+}
+
+/**
+ * Build a public or endpoint-based URL for an object key without presigning.
+ */
+export function buildObjectUrl(objectKey: string): string {
+  const bucket = process.env.CLOUD_STORAGE_BUCKET;
+  const endpoint = process.env.CLOUD_STORAGE_ENDPOINT;
+  const region = process.env.CLOUD_STORAGE_REGION ?? "us-east-1";
+
+  if (!bucket) {
+    return `https://storage.example.com/${objectKey}`;
+  }
+
+  if (endpoint) {
+    return `${endpoint.replace(/\/$/, "")}/${bucket}/${objectKey}`;
+  }
+
+  return `https://${bucket}.s3.${region}.amazonaws.com/${objectKey}`;
+}
 
 // Multipart threshold: files larger than 50 MB use multipart upload.
 const MULTIPART_THRESHOLD = 50 * 1024 * 1024; // 50 MB

--- a/app/lib/planLimits.ts
+++ b/app/lib/planLimits.ts
@@ -1,0 +1,28 @@
+export type UserPlan = "free" | "pro" | "enterprise";
+export type ExportQuality = "720p" | "1080p";
+
+const MAX_EXPORT_QUALITY: Record<UserPlan, ExportQuality> = {
+  free: "720p",
+  pro: "1080p",
+  enterprise: "1080p",
+};
+
+const QUALITY_RANK: Record<ExportQuality, number> = {
+  "720p": 1,
+  "1080p": 2,
+};
+
+/**
+ * Returns the maximum export quality allowed for a plan.
+ */
+export function getMaxExportQuality(plan: string): ExportQuality {
+  return MAX_EXPORT_QUALITY[plan as UserPlan] ?? "720p";
+}
+
+/**
+ * Whether the requested quality is allowed for the user's plan.
+ */
+export function isExportQualityAllowed(plan: string, quality: ExportQuality): boolean {
+  const max = getMaxExportQuality(plan);
+  return QUALITY_RANK[quality] <= QUALITY_RANK[max];
+}

--- a/components/projects/ClipGrid.tsx
+++ b/components/projects/ClipGrid.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import React, { useRef, useEffect, useState } from "react";
+import React, { useRef, useEffect } from "react";
 import Image from "next/image";
-import { Check, Edit2, Play, Sparkles, BarChart3, Download, Loader2 } from "lucide-react";
-import analytics from "@/app/lib/analytics";
+import { Check, Edit2, Play, Sparkles, BarChart3 } from "lucide-react";
 import ScoreBreakdownTooltip, { ScoreBreakdown } from "./ScoreBreakdownTooltip";
+import ExportDropdown from "./ExportDropdown";
 
 export interface Clip {
   id: string;
@@ -39,6 +39,7 @@ export interface ClipGridProps {
   loadingNextPage: boolean;
   onLoadMore: () => void;
   hasMore: boolean;
+  userPlan?: "free" | "pro" | "enterprise";
 }
 
 export default function ClipGrid({
@@ -60,9 +61,9 @@ export default function ClipGrid({
   loadingNextPage,
   onLoadMore,
   hasMore,
+  userPlan = "free",
 }: ClipGridProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
-  const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!hasMore || loadingNextPage) return;
@@ -76,24 +77,6 @@ export default function ClipGrid({
 
   const handleKeyDown = (e: React.KeyboardEvent, id: string) => {
     if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(id); }
-  };
-
-  const handleDownload = async (clipId: string) => {
-    setDownloadingId(clipId);
-    try {
-      const res = await fetch(`/api/clips/${clipId}/download`);
-      if (!res.ok) throw new Error("Download failed");
-      const { url } = await res.json();
-      analytics.trackEvent("clip_downloaded", { clipId });
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `clip-${clipId}.mp4`;
-      a.click();
-    } catch {
-      // silently fail
-    } finally {
-      setDownloadingId(null);
-    }
   };
 
   if (loading) {
@@ -166,10 +149,7 @@ export default function ClipGrid({
               <div className="absolute bottom-0 left-0 right-0 p-3 bg-black/90 translate-y-full group-hover:translate-y-0 transition-transform flex items-center-stretch gap-2 backdrop-blur-md">
                 <button onClick={(e) => { e.stopPropagation(); onPreview(clip.id); }} className="flex-1 bg-white/10 hover:bg-white/20 text-white py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-colors" aria-label="Preview clip"><Play className="w-4 h-4" /> Preview</button>
                 <button onClick={(e) => { e.stopPropagation(); onEdit(clip.id); }} className="flex-1 bg-white/10 hover:bg-white/20 text-white py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-colors" aria-label="Edit clip"><Edit2 className="w-4 h-4" /> Edit</button>
-                <button onClick={(e) => { e.stopPropagation(); handleDownload(clip.id); }} disabled={downloadingId === clip.id} className="flex-1 bg-white/10 hover:bg-white/20 text-white py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-colors disabled:opacity-50" aria-label="Download clip">
-                  {downloadingId === clip.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
-                  {downloadingId === clip.id ? "..." : "Download"}
-                </button>
+                <ExportDropdown clipId={clip.id} userPlan={userPlan} />
                 <a href={`/analytics?clipId=${clip.id}`} onClick={(e) => e.stopPropagation()} className="flex-1 bg-white/10 hover:bg-white/20 text-white py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-colors" aria-label="View analytics"><BarChart3 className="w-4 h-4" /> Analytics</a>
               </div>
             </div>

--- a/components/projects/ExportDropdown.tsx
+++ b/components/projects/ExportDropdown.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { Download, ChevronDown, Loader2, Check } from "lucide-react";
+import analytics from "@/app/lib/analytics";
+
+export interface ExportOptions {
+  format: "mp4" | "webm";
+  aspectRatio: "9:16" | "1:1" | "16:9";
+  quality: "720p" | "1080p";
+}
+
+interface ExportDropdownProps {
+  clipId: string;
+  userPlan?: "free" | "pro" | "enterprise";
+  onExportStarted?: () => void;
+}
+
+const FORMATS: ExportOptions["format"][] = ["mp4", "webm"];
+const ASPECT_RATIOS: ExportOptions["aspectRatio"][] = ["9:16", "1:1", "16:9"];
+const QUALITIES: ExportOptions["quality"][] = ["720p", "1080p"];
+
+export default function ExportDropdown({
+  clipId,
+  userPlan = "free",
+  onExportStarted,
+}: ExportDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [options, setOptions] = useState<ExportOptions>({
+    format: "mp4",
+    aspectRatio: "9:16",
+    quality: "720p",
+  });
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const isQualityDisabled = (quality: ExportOptions["quality"]) =>
+    userPlan === "free" && quality === "1080p";
+
+  const handleExport = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isQualityDisabled(options.quality)) return;
+
+    setExporting(true);
+    setSuccess(false);
+
+    try {
+      const res = await fetch(`/api/clips/${clipId}/transcode`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(options),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message ?? "Export failed");
+      }
+
+      analytics.trackEvent("clip_export_started", {
+        clipId,
+        format: options.format,
+        aspectRatio: options.aspectRatio,
+        quality: options.quality,
+      });
+
+      setSuccess(true);
+      onExportStarted?.();
+      setTimeout(() => {
+        setSuccess(false);
+        setOpen(false);
+      }, 2000);
+    } catch {
+      // silently fail
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div ref={ref} className="relative flex-1" onClick={(e) => e.stopPropagation()}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="w-full bg-white/10 hover:bg-white/20 text-white py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-1 transition-colors"
+        aria-label="Export clip"
+        aria-expanded={open}
+      >
+        {exporting ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : success ? (
+          <Check className="w-4 h-4 text-brand" />
+        ) : (
+          <Download className="w-4 h-4" />
+        )}
+        Export
+        <ChevronDown className={`w-3 h-3 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="absolute bottom-full left-0 right-0 mb-2 bg-[#1a1a1a] border border-white/10 rounded-xl p-3 shadow-xl z-20 space-y-3 min-w-[200px]">
+          <div>
+            <label className="text-[10px] uppercase text-white/50 font-bold mb-1 block">Format</label>
+            <div className="flex gap-1">
+              {FORMATS.map((f) => (
+                <button
+                  key={f}
+                  onClick={() => setOptions((o) => ({ ...o, format: f }))}
+                  className={`flex-1 py-1 rounded text-xs font-medium ${
+                    options.format === f ? "bg-brand text-black" : "bg-white/5 text-white/70"
+                  }`}
+                >
+                  {f.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="text-[10px] uppercase text-white/50 font-bold mb-1 block">Aspect Ratio</label>
+            <div className="flex gap-1">
+              {ASPECT_RATIOS.map((r) => (
+                <button
+                  key={r}
+                  onClick={() => setOptions((o) => ({ ...o, aspectRatio: r }))}
+                  className={`flex-1 py-1 rounded text-xs font-medium ${
+                    options.aspectRatio === r ? "bg-brand text-black" : "bg-white/5 text-white/70"
+                  }`}
+                >
+                  {r}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="text-[10px] uppercase text-white/50 font-bold mb-1 block">Quality</label>
+            <div className="flex gap-1">
+              {QUALITIES.map((q) => {
+                const disabled = isQualityDisabled(q);
+                return (
+                  <button
+                    key={q}
+                    disabled={disabled}
+                    onClick={() => setOptions((o) => ({ ...o, quality: q }))}
+                    className={`flex-1 py-1 rounded text-xs font-medium ${
+                      options.quality === q ? "bg-brand text-black" : "bg-white/5 text-white/70"
+                    } ${disabled ? "opacity-40 cursor-not-allowed" : ""}`}
+                    title={disabled ? "Pro plan required" : undefined}
+                  >
+                    {q}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <button
+            onClick={handleExport}
+            disabled={exporting || isQualityDisabled(options.quality)}
+            className="w-full py-2 bg-brand text-black rounded-lg text-xs font-bold hover:bg-brand-hover disabled:opacity-50"
+          >
+            {exporting ? "Starting..." : "Start Export"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- POST /api/clips/:id/transcode and GET /api/clips/:id/exports
- S3 exports/ prefix with plan-gated quality (Free 720p, Pro 1080p)
- Export dropdown on clip cards
- Async transcoding job dispatch to AI backend

## Test plan
- [ ] POST transcode with format/aspectRatio/quality
- [ ] GET exports returns status and download URLs
- [ ] Free plan blocked from 1080p

Closes #823