### PR TITLE
feat: add project-level clip organisation (#825)

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -191,6 +191,7 @@ export default function DashboardPage() {
                 : recentProjects.map((project) => (
                     <ProjectCard
                       key={project.id}
+                      id={project.id}
                       title={project.title}
                       clipsCount={project.clipsGenerated}
                       status={project.status}

--- a/app/(dashboard)/projects/[id]/page.tsx
+++ b/app/(dashboard)/projects/[id]/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft, Pencil, Trash2, Play, Sparkles } from "lucide-react";
+import { useToast } from "@/hooks/useToast";
+import type { Clip } from "@/components/projects/ClipGrid";
+
+interface ProjectDetail {
+  id: string;
+  name: string;
+  thumbnailUrl: string;
+  videoUrl: string;
+  clipCount: number;
+}
+
+export default function ProjectDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const projectId = params.id as string;
+  const { showToast, ToastEl } = useToast();
+
+  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [clips, setClips] = useState<Clip[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [renaming, setRenaming] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  const fetchProject = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [projRes, clipsRes] = await Promise.all([
+        fetch(`/api/projects/${projectId}`),
+        fetch(`/api/projects/${projectId}/clips`),
+      ]);
+
+      if (!projRes.ok) throw new Error("Project not found");
+      const projJson = await projRes.json();
+      setProject(projJson.data);
+      setNewName(projJson.data.name);
+
+      if (clipsRes.ok) {
+        const clipsJson = await clipsRes.json();
+        setClips(clipsJson.data?.clips ?? []);
+      }
+    } catch {
+      showToast("Failed to load project", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId, showToast]);
+
+  useEffect(() => {
+    fetchProject();
+  }, [fetchProject]);
+
+  const handleRename = async () => {
+    if (!newName.trim()) return;
+    try {
+      const res = await fetch(`/api/projects/${projectId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newName.trim() }),
+      });
+      if (!res.ok) throw new Error("Rename failed");
+      setRenaming(false);
+      showToast("Project renamed", "success");
+      fetchProject();
+    } catch {
+      showToast("Failed to rename project", "error");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm("Delete this project and all its clips?")) return;
+    try {
+      const res = await fetch(`/api/projects/${projectId}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Delete failed");
+      showToast("Project deleted", "success");
+      router.push("/projects");
+    } catch {
+      showToast("Failed to delete project", "error");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="w-8 h-8 border-4 border-brand border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-muted-foreground">Project not found</p>
+        <Link href="/projects" className="text-brand hover:underline mt-4 inline-block">
+          Back to Projects
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8 max-w-[1400px] mx-auto w-full">
+      {ToastEl}
+
+      <div className="flex items-center gap-4">
+        <Link
+          href="/projects"
+          className="p-2 rounded-xl bg-white/5 hover:bg-white/10 text-white/70 hover:text-white transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </Link>
+        <div className="flex-1">
+          {renaming ? (
+            <div className="flex items-center gap-2">
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                className="bg-white/5 border border-white/10 rounded-xl px-3 py-2 text-white text-xl font-bold"
+                autoFocus
+              />
+              <button onClick={handleRename} className="px-4 py-2 bg-brand text-black rounded-xl text-sm font-bold">
+                Save
+              </button>
+              <button onClick={() => setRenaming(false)} className="px-4 py-2 bg-white/5 text-white rounded-xl text-sm">
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-extrabold text-white">{project.name}</h1>
+              <button
+                onClick={() => setRenaming(true)}
+                className="p-2 rounded-lg hover:bg-white/10 text-white/50 hover:text-white"
+                aria-label="Rename project"
+              >
+                <Pencil className="w-4 h-4" />
+              </button>
+              <button
+                onClick={handleDelete}
+                className="p-2 rounded-lg hover:bg-red-500/10 text-white/50 hover:text-red-400"
+                aria-label="Delete project"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+          <p className="text-muted-foreground text-sm mt-1">{clips.length} clips</p>
+        </div>
+      </div>
+
+      <div className="relative aspect-video max-w-2xl rounded-2xl overflow-hidden bg-black">
+        <Image src={project.thumbnailUrl} alt={project.name} fill className="object-cover opacity-60" />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <a
+            href={project.videoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-16 h-16 rounded-full bg-brand/90 flex items-center justify-center hover:scale-105 transition-transform"
+          >
+            <Play className="w-8 h-8 text-black ml-1" />
+          </a>
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-lg font-bold text-white mb-4">Project Clips</h2>
+        {clips.length === 0 ? (
+          <div className="text-center py-12 bg-white/5 rounded-2xl">
+            <Sparkles className="w-8 h-8 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No clips in this project yet</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {clips.map((clip) => (
+              <div key={clip.id} className="rounded-2xl overflow-hidden border border-white/10 bg-white/5">
+                <div className="aspect-[9/16] relative">
+                  <Image src={clip.thumbnail} alt={clip.title} fill className="object-cover" />
+                  <div className="absolute top-3 left-3 bg-brand text-black px-2 py-0.5 rounded text-xs font-bold">
+                    {clip.score}
+                  </div>
+                </div>
+                <div className="p-3">
+                  <h4 className="text-white font-bold text-sm truncate">{clip.title}</h4>
+                  <p className="text-xs text-muted-foreground">{clip.duration} · {clip.style}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/clips/clipsStore.ts
+++ b/app/api/clips/clipsStore.ts
@@ -10,6 +10,7 @@ export interface ScoreBreakdown {
 export interface Clip {
   id: string;
   userId: string;
+  projectId?: string;
   title: string;
   thumbnail: string;
   score: number;
@@ -45,9 +46,10 @@ class ClipsStore {
     ];
     
     // Create base pool that users will pull from 
-    this.clips = mockClips.map(clip => ({
+    this.clips = mockClips.map((clip, idx) => ({
       ...clip,
       userId: "default", // will be replaced when requested
+      projectId: `default-proj-${(idx % 3) + 1}`,
       createdAt: new Date().toISOString()
     }));
   }
@@ -66,7 +68,8 @@ class ClipsStore {
       const newClips = this.clips.filter(c => c.userId === "default").map((c, idx) => ({
         ...c,
         id: `${userId}-clip-${idx}`,
-        userId
+        userId,
+        projectId: `${userId}-proj-${(idx % 3) + 1}`,
       }));
       this.clips.push(...newClips);
       return newClips;
@@ -188,6 +191,18 @@ class ClipsStore {
       this.clips.filter(c => c.userId === userId).map(c => c.id),
     );
     return clipIds.filter(id => !owned.has(id));
+  }
+
+  getClipsForProject(userId: string, projectId: string): Clip[] {
+    return this.getClipsForUser(userId).filter((c) => c.projectId === projectId);
+  }
+
+  /** Cascade soft-delete all clips belonging to a project. */
+  softDeleteClipsByProject(userId: string, projectId: string): number {
+    const clipIds = this.clips
+      .filter((c) => c.userId === userId && c.projectId === projectId && !c.deletedAt)
+      .map((c) => c.id);
+    return this.softDeleteClips(userId, clipIds);
   }
 }
 

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -3,7 +3,8 @@ import { auth } from "@/app/lib/auth";
 import { requireAuth } from "@/app/api/jobs/shared/authGuard";
 import { applyRateLimit } from "@/app/lib/serverRateLimit";
 import { earningsStore } from "@/app/api/earnings/earningsStore";
-import { jobStore } from "@/app/api/jobs/shared/jobStore";
+import { projectsStore } from "@/app/api/projects/projectsStore";
+import { clipsStore } from "@/app/api/clips/clipsStore";
 import type { ApiResponse } from "../types";
 import type {
   DashboardStats,
@@ -91,26 +92,28 @@ export async function GET(request: NextRequest) {
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
   // 2. Calculate Clips stats & Recent Projects
-  const userJobs = await jobStore.getUserJobs(userId);
-  const totalClipsNum = userJobs.reduce(
-    (acc, j) => acc + (j.momentsFound || (j.status === "complete" ? 1 : 0)),
-    0
+  const userProjects = projectsStore.getProjectsForUser(userId);
+  clipsStore.getClipsForUser(userId);
+  const totalClipsNum = userProjects.reduce(
+    (acc, p) => acc + clipsStore.getClipsForProject(userId, p.id).length,
+    0,
   );
 
-  const currentPeriodJobs = userJobs.filter(
-    (j) => j.createdAt >= now.getTime() - thirtyDaysMs
+  const currentPeriodProjects = userProjects.filter(
+    (p) => new Date(p.createdAt).getTime() >= now.getTime() - thirtyDaysMs,
   );
-  const priorPeriodJobs = userJobs.filter(
-    (j) => j.createdAt >= now.getTime() - 2 * thirtyDaysMs && j.createdAt < now.getTime() - thirtyDaysMs
-  );
+  const priorPeriodProjects = userProjects.filter((p) => {
+    const t = new Date(p.createdAt).getTime();
+    return t >= now.getTime() - 2 * thirtyDaysMs && t < now.getTime() - thirtyDaysMs;
+  });
 
-  const currentClipsSum = currentPeriodJobs.reduce(
-    (acc, j) => acc + (j.momentsFound || 1),
-    0
+  const currentClipsSum = currentPeriodProjects.reduce(
+    (acc, p) => acc + clipsStore.getClipsForProject(userId, p.id).length,
+    0,
   );
-  const priorClipsSum = priorPeriodJobs.reduce(
-    (acc, j) => acc + (j.momentsFound || 1),
-    0
+  const priorClipsSum = priorPeriodProjects.reduce(
+    (acc, p) => acc + clipsStore.getClipsForProject(userId, p.id).length,
+    0,
   );
 
   let clipsTrend = 0;
@@ -135,19 +138,14 @@ export async function GET(request: NextRequest) {
     trendLabel: clipsTrendLabel,
   };
 
-  const sortedJobs = [...userJobs].sort((a, b) => b.createdAt - a.createdAt);
-  const recentProjects: Project[] = sortedJobs.slice(0, 6).map((job) => {
-    const filename = (job as { filename?: string }).filename;
-    const title = filename
-      ? filename.replace(/\.[^/.]+$/, "")
-      : `Project ${job.id.slice(0, 6)}`;
-
+  const recentProjects: Project[] = userProjects.slice(0, 6).map((project) => {
+    const clipCount = clipsStore.getClipsForProject(userId, project.id).length;
     return {
-      id: job.id,
-      title,
-      clipsGenerated: job.momentsFound || 0,
-      status: job.status === "complete" ? "completed" : "processing",
-      image: "/projects/thumb1.png",
+      id: project.id,
+      title: project.name,
+      clipsGenerated: clipCount,
+      status: clipCount > 0 ? "completed" : "processing",
+      image: project.thumbnailUrl,
       accent: "",
     };
   });

--- a/app/api/projects/[id]/clips/route.ts
+++ b/app/api/projects/[id]/clips/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/app/api/jobs/shared/authGuard";
+import { projectsStore } from "@/app/api/projects/projectsStore";
+import { clipsStore } from "@/app/api/clips/clipsStore";
+import type { ApiResponse } from "@/app/api/types";
+
+/**
+ * GET /api/projects/:id/clips — list clips for a specific project.
+ */
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const { id: projectId } = await context.params;
+  const project = projectsStore.getProjectById(userId, projectId);
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+
+  const allClips = clipsStore.getClipsForProject(userId, projectId);
+  const total = allClips.length;
+  const start = (page - 1) * pageSize;
+  const clips = allClips.slice(start, start + pageSize);
+
+  const body: ApiResponse<{
+    project: { id: string; name: string; thumbnailUrl: string };
+    clips: typeof clips;
+    total: number;
+    page: number;
+    pageSize: number;
+  }> = {
+    data: {
+      project: {
+        id: project.id,
+        name: project.name,
+        thumbnailUrl: project.thumbnailUrl,
+      },
+      clips,
+      total,
+      page,
+      pageSize,
+    },
+    error: null,
+  };
+
+  return NextResponse.json(body);
+}

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCsrf } from "@/app/lib/csrf";
+import { requireAuth } from "@/app/api/jobs/shared/authGuard";
+import { parseRequestJson } from "@/app/lib/parseRequestJson";
+import { projectsStore } from "@/app/api/projects/projectsStore";
+import { clipsStore } from "@/app/api/clips/clipsStore";
+import { renameProjectBodySchema } from "@/app/api/schemas/projects.schema";
+import type { ApiResponse } from "@/app/api/types";
+
+/**
+ * GET /api/projects/:id — get project details.
+ * PATCH — rename project.
+ * DELETE — soft delete project and cascade to clips.
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const { id: projectId } = await context.params;
+  const project = projectsStore.getProjectById(userId, projectId);
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const clips = clipsStore.getClipsForProject(userId, projectId);
+
+  const body: ApiResponse<{
+    id: string;
+    name: string;
+    thumbnailUrl: string;
+    videoUrl: string;
+    videoObjectKey: string;
+    clipCount: number;
+    createdAt: string;
+  }> = {
+    data: {
+      id: project.id,
+      name: project.name,
+      thumbnailUrl: project.thumbnailUrl,
+      videoUrl: project.videoUrl,
+      videoObjectKey: project.videoObjectKey,
+      clipCount: clips.length,
+      createdAt: project.createdAt,
+    },
+    error: null,
+  };
+
+  return NextResponse.json(body);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const { id: projectId } = await context.params;
+
+  const parsedBody = await parseRequestJson(request);
+  if (!parsedBody.ok) return parsedBody.response;
+
+  const validation = renameProjectBodySchema.safeParse(parsedBody.body);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: validation.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const updated = projectsStore.renameProject(userId, projectId, validation.data.name);
+  if (!updated) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const body: ApiResponse<{ success: boolean; project: typeof updated }> = {
+    data: { success: true, project: updated },
+    error: null,
+  };
+
+  return NextResponse.json(body);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const { id: projectId } = await context.params;
+
+  const deleted = projectsStore.softDeleteProject(userId, projectId);
+  if (!deleted) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const deletedClips = clipsStore.softDeleteClipsByProject(userId, projectId);
+
+  const body: ApiResponse<{ success: boolean; deletedClips: number }> = {
+    data: { success: true, deletedClips },
+    error: null,
+  };
+
+  return NextResponse.json(body);
+}

--- a/app/api/projects/projectsStore.ts
+++ b/app/api/projects/projectsStore.ts
@@ -1,0 +1,101 @@
+export interface Project {
+  id: string;
+  userId: string;
+  name: string;
+  thumbnailUrl: string;
+  videoUrl: string;
+  videoObjectKey: string;
+  createdAt: string;
+  deletedAt?: string | null;
+}
+
+class ProjectsStore {
+  private projects: Project[] = [];
+
+  constructor() {
+    this.seed();
+  }
+
+  private seed() {
+    this.projects = [
+      {
+        id: "proj-1",
+        userId: "default",
+        name: "Product Launch Keynote",
+        thumbnailUrl: "/projects/thumb1.png",
+        videoUrl: "https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+        videoObjectKey: "uploads/proj-1/source.mp4",
+        createdAt: new Date(Date.now() - 86400000 * 3).toISOString(),
+      },
+      {
+        id: "proj-2",
+        userId: "default",
+        name: "Podcast Episode #42",
+        thumbnailUrl: "/projects/thumb2.png",
+        videoUrl: "https://storage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+        videoObjectKey: "uploads/proj-2/source.mp4",
+        createdAt: new Date(Date.now() - 86400000).toISOString(),
+      },
+      {
+        id: "proj-3",
+        userId: "default",
+        name: "Tutorial Series Intro",
+        thumbnailUrl: "/projects/thumb3.png",
+        videoUrl: "https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
+        videoObjectKey: "uploads/proj-3/source.mp4",
+        createdAt: new Date().toISOString(),
+      },
+    ];
+  }
+
+  private ensureUserProjects(userId: string): void {
+    const existing = this.projects.filter((p) => p.userId === userId && !p.deletedAt);
+    if (existing.length === 0) {
+      const seeded = this.projects
+        .filter((p) => p.userId === "default")
+        .map((p, idx) => ({
+          ...p,
+          id: `${userId}-proj-${idx + 1}`,
+          userId,
+        }));
+      this.projects.push(...seeded);
+    }
+  }
+
+  getProjectsForUser(userId: string): Project[] {
+    this.ensureUserProjects(userId);
+    return this.projects
+      .filter((p) => p.userId === userId && !p.deletedAt)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }
+
+  getProjectById(userId: string, projectId: string): Project | undefined {
+    this.ensureUserProjects(userId);
+    return this.projects.find(
+      (p) => p.id === projectId && p.userId === userId && !p.deletedAt,
+    );
+  }
+
+  renameProject(userId: string, projectId: string, name: string): Project | undefined {
+    const index = this.projects.findIndex(
+      (p) => p.id === projectId && p.userId === userId && !p.deletedAt,
+    );
+    if (index === -1) return undefined;
+    this.projects[index] = { ...this.projects[index], name };
+    return this.projects[index];
+  }
+
+  softDeleteProject(userId: string, projectId: string): boolean {
+    const index = this.projects.findIndex(
+      (p) => p.id === projectId && p.userId === userId && !p.deletedAt,
+    );
+    if (index === -1) return false;
+    this.projects[index] = {
+      ...this.projects[index],
+      deletedAt: new Date().toISOString(),
+    };
+    return true;
+  }
+}
+
+export const projectsStore = new ProjectsStore();

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { requireAuth } from "@/app/api/jobs/shared/authGuard";
+import { clipsStore } from "@/app/api/clips/clipsStore";
+import { projectsStore } from "./projectsStore";
+import type { ApiResponse } from "../types";
+
+/**
+ * GET /api/projects — list all projects for the authenticated user.
+ */
+export async function GET() {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const { userId } = authResult;
+
+  const projects = projectsStore.getProjectsForUser(userId);
+  clipsStore.getClipsForUser(userId);
+
+  const body: ApiResponse<{
+    projects: Array<{
+      id: string;
+      name: string;
+      thumbnailUrl: string;
+      videoUrl: string;
+      clipCount: number;
+      createdAt: string;
+    }>;
+  }> = {
+    data: {
+      projects: projects.map((p) => ({
+        id: p.id,
+        name: p.name,
+        thumbnailUrl: p.thumbnailUrl,
+        videoUrl: p.videoUrl,
+        clipCount: clipsStore.getClipsForProject(userId, p.id).length,
+        createdAt: p.createdAt,
+      })),
+    },
+    error: null,
+  };
+
+  return NextResponse.json(body);
+}

--- a/app/api/schemas/index.ts
+++ b/app/api/schemas/index.ts
@@ -10,3 +10,4 @@ export * from "./clips.schema";
 export * from "./user.schema";
 export * from "./transform.schema";
 export * from "./billing.schema";
+export * from "./projects.schema";

--- a/app/api/schemas/projects.schema.ts
+++ b/app/api/schemas/projects.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const renameProjectBodySchema = z.object({
+  name: z.string().min(1, "Name is required").max(200),
+});
+
+export type RenameProjectBody = z.infer<typeof renameProjectBodySchema>;

--- a/components/dashboard/ProjectCard.tsx
+++ b/components/dashboard/ProjectCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { sanitize } from "@/app/lib/sanitize";
 
 export interface ProjectCardProps {
@@ -11,12 +12,13 @@ export interface ProjectCardProps {
 }
 
 export default function ProjectCard({
+  id,
   title,
   clipsCount = 0,
   status = "Completed",
   thumbnail,
 }: ProjectCardProps) {
-  return (
+  const content = (
     <div className="bg-surface border border-white/10 rounded-[24px] p-5 flex items-center gap-5 hover:border-brand/50 transition-colors">
       <div className="relative w-24 h-24 rounded-[18px] overflow-hidden shrink-0 bg-input">
         <Image
@@ -37,4 +39,14 @@ export default function ProjectCard({
       </div>
     </div>
   );
+
+  if (id) {
+    return (
+      <Link href={`/projects/${id}`} className="block">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
 }

--- a/components/dashboard/ProjectSelector.tsx
+++ b/components/dashboard/ProjectSelector.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { FolderOpen, ChevronDown } from "lucide-react";
+
+interface ProjectItem {
+  id: string;
+  name: string;
+}
+
+export default function ProjectSelector() {
+  const pathname = usePathname();
+  const [projects, setProjects] = useState<ProjectItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const activeProjectId = pathname.match(/^\/projects\/([^/]+)$/)?.[1];
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (json?.data?.projects) {
+          setProjects(json.data.projects.map((p: { id: string; name: string }) => ({
+            id: p.id,
+            name: p.name,
+          })));
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading || projects.length === 0) return null;
+
+  const activeProject = projects.find((p) => p.id === activeProjectId);
+
+  return (
+    <div className="px-3 mb-2">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-xl bg-white/5 hover:bg-white/10 text-white/70 hover:text-white text-sm transition-colors"
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-2 truncate">
+          <FolderOpen className="w-4 h-4 shrink-0" />
+          <span className="truncate">{activeProject?.name ?? "All Projects"}</span>
+        </span>
+        <ChevronDown className={`w-4 h-4 shrink-0 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="mt-1 bg-surface border border-border rounded-xl overflow-hidden shadow-lg">
+          <Link
+            href="/projects"
+            onClick={() => setOpen(false)}
+            className={`block px-3 py-2 text-sm hover:bg-white/5 transition-colors ${
+              !activeProjectId ? "text-brand font-medium" : "text-white/70"
+            }`}
+          >
+            All Projects
+          </Link>
+          {projects.map((project) => (
+            <Link
+              key={project.id}
+              href={`/projects/${project.id}`}
+              onClick={() => setOpen(false)}
+              className={`block px-3 py-2 text-sm hover:bg-white/5 transition-colors truncate ${
+                activeProjectId === project.id ? "text-brand font-medium" : "text-white/70"
+              }`}
+            >
+              {project.name}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Projects API with rename and soft-delete (cascade to clips)
- Dashboard live projects, sidebar selector, /projects/[id] detail page

Closes #825

Made with [Cursor](https://cursor.com)